### PR TITLE
Add a link to project wiki to provide some direction on how to get started

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,8 @@ engine and content creation tool -- would not exist.
 Katana can be set up much like a normal Buildbot instance, but more detailed
 instructions and examples are in-progress.
 
+For now, start here: https://github.com/Unity-Technologies/katana/wiki
+
 Katana Maintainers List w/ Contact Info:
 
     Maria Marcano


### PR DESCRIPTION
It wasn't obvious that there was content on the project wiki on how to get started. I would've expected a link from the README to point me there. This change adds the link. :)

Also, it's not really clear on the current project status--is there a branch that's considered "stable" that people can use or should we wait for what looks like a lot of in-progress development work to come to fruition?

I'm really interested in trying out Katana but I'm it's not clear if it's currently in a state where that would be productive. :)