### PR TITLE
Hotfix/start build latency optimizations

### DIFF
--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -232,7 +232,8 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
 
             pending = sa.select([reqs_tbl.c.buildername, reqs_tbl.c.priority,
                                  reqs_tbl.c.submitted_at, reqs_tbl.c.results,
-                                 buildset_properties_tbl.c.property_value],
+                                 buildset_properties_tbl.c.property_value,
+                                 reqs_tbl.c.slavepool],
                           from_obj=reqs_tbl.outerjoin(claims_tbl, (reqs_tbl.c.id == claims_tbl.c.brid))
                                 .outerjoin(buildset_properties_tbl,
                                       (buildset_properties_tbl.c.buildsetid == reqs_tbl.c.buildsetid)
@@ -244,7 +245,8 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
 
             resumebuilds = sa.select([reqs_tbl.c.buildername, reqs_tbl.c.priority,
                                       reqs_tbl.c.submitted_at, reqs_tbl.c.results,
-                                      buildset_properties_tbl.c.property_value],
+                                      buildset_properties_tbl.c.property_value,
+                                      reqs_tbl.c.slavepool],
                                from_obj=reqs_tbl.join(claims_tbl,
                                                       (reqs_tbl.c.id == claims_tbl.c.brid)
                                                       & (claims_tbl.c.objectid == _master_objectid))
@@ -271,7 +273,8 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
                                    priority=row.priority,
                                    submitted_at=mkdt(row.submitted_at),
                                    results=row.results,
-                                   selected_slave=getSelectedSlave(row)))
+                                   selected_slave=getSelectedSlave(row),
+                                   slavepool=row.slavepool))
 
             return rv
 

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -224,7 +224,7 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
         return self.db.pool.do(thd)
 
     @with_master_objectid
-    def getOldestBuildRequestInQueue(self, buildername, _master_objectid=None):
+    def getPrioritizedBuildRequestsInQueue(self, buildername, _master_objectid=None):
         def thd(conn):
             reqs_tbl = self.db.model.buildrequests
             claims_tbl = self.db.model.buildrequest_claims

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -147,9 +147,10 @@ class Builder(config.ReconfigurableServiceMixin,
                 return sb
 
     @defer.inlineCallbacks
-    def getPrioritizedBuildRequest(self):
+    def getPrioritizedBuildRequest(self, queue=None):
 
-        buildrequestQueue = yield self.master.db.buildrequests.getPrioritizedBuildRequestsInQueue(buildername=self.name)
+        buildrequestQueue = yield self.master.db.buildrequests\
+            .getPrioritizedBuildRequestsInQueue(buildername=self.name, queue=queue)
 
         if buildrequestQueue:
             sortedRequests = sorted(buildrequestQueue, key=lambda br: (-br["priority"], br["submitted_at"]))

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -149,8 +149,23 @@ class Builder(config.ReconfigurableServiceMixin,
     @defer.inlineCallbacks
     def getPrioritizedBuildRequest(self, queue=None):
 
+        getSlavesFunc = self.getAvailableSlaves if queue == 'unclaimed' \
+            else self.getAvailableSlavesToResume if queue == 'resume' \
+            else self.getAllSlaves
+
+        availableSlavesToProcessBuildRequests = [slavebuilder.slave.slavename
+                                  for slavebuilder in getSlavesFunc()
+                                  if slavebuilder.isAvailable()]
+
+        if len(availableSlavesToProcessBuildRequests) < 1:
+            defer.returnValue(None)
+            return
+
+        # TODO: check performance when there are many things in queue, maybe it will be faster to limit the search
+        # we may need to do the same for KatanaBuildChooser
         buildrequestQueue = yield self.master.db.buildrequests\
-            .getPrioritizedBuildRequestsInQueue(buildername=self.name, queue=queue)
+            .getPrioritizedBuildRequestsInQueue(buildername=self.name,
+                                                queue=queue)
 
         if buildrequestQueue:
             sortedRequests = sorted(buildrequestQueue, key=lambda br: (-br["priority"], br["submitted_at"]))

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -149,6 +149,18 @@ class Builder(config.ReconfigurableServiceMixin,
     @defer.inlineCallbacks
     def getPrioritizedBuildRequest(self, queue=None):
 
+        """
+        Finds the next build request that should run on the builder
+        selecting the one with the higher priority and oldest submitted time.
+
+        it will return None right away if there are no slaves available for the task.
+
+        @param queue: None will select the higher priority overall pending buids,
+        if queue is 'unclaimed' will select only the pending builds and if queue='resume'
+        it will select only builds pending to be resume
+        @returns: a build request dictionary or None via Deferred
+        """
+
         getSlavesFunc = self.getAvailableSlaves if queue == 'unclaimed' \
             else self.getAvailableSlavesToResume if queue == 'resume' \
             else self.getAllSlaves
@@ -163,7 +175,7 @@ class Builder(config.ReconfigurableServiceMixin,
 
         # TODO: check performance when there are many things in queue, maybe it will be faster to limit the search
         # we may need to do the same for KatanaBuildChooser
-        buildrequestQueue = yield self.master.db.buildrequests\
+        buildrequestQueue = yield self.master.db.buildrequests \
             .getPrioritizedBuildRequestsInQueue(buildername=self.name,
                                                 queue=queue)
 

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -882,7 +882,7 @@ class BuildRequestDistributor(service.Service):
                                   key=lambda (br, priority_bldr): (-br["priority"], br["submitted_at"])
                                   if br else (True, True))
 
-        rv = [sorted_bldr[1] for sorted_bldr in priorityBuilders]
+        rv = [sorted_bldr[1] for sorted_bldr in priorityBuilders if sorted_bldr[0] is not None]
         timer.stop()
         defer.returnValue(rv)
 
@@ -969,8 +969,11 @@ class BuildRequestDistributor(service.Service):
         self._quiet()
 
     def logResumeOrStartBuildStatus(self, msg, slave, breqs):
-        log.msg(" %s for buildername %s using slave %s buildrequest id %d priority %d submittedAt %s" %
-                (msg, breqs[0].buildername, slave, breqs[0].id, breqs[0].priority, epoch2datetime(breqs[0].submittedAt)))
+        if len(breqs) > 0:
+            log.msg(" %s for buildername %s using slave %s buildrequest id %d priority %d submittedAt %s buildsetid %d" %
+                    (msg, breqs[0].buildername, slave, breqs[0].id, breqs[0].priority,
+                     epoch2datetime(breqs[0].submittedAt),
+                     breqs[0].bsid))
 
     @defer.inlineCallbacks
     def _maybeResumeBuildOnBuilder(self, bc, bldr):

--- a/master/buildbot/steps/resumebuild.py
+++ b/master/buildbot/steps/resumebuild.py
@@ -12,10 +12,10 @@ class ResumeBuild(LoggingBuildStep):
     description="Resume Build..."
     descriptionDone="Resume Build"
 
-    def __init__(self, resumeBuild=True, resumeSlavepool=None, **kwargs):
+    def __init__(self, resumeBuild=True, resumeSlavepool=None, haltOnFailure=True, **kwargs):
         self.resumeBuild = resumeBuild if resumeBuild is not None else True
         self.resumeSlavepool = "slavenames" if resumeSlavepool is None else resumeSlavepool
-        LoggingBuildStep.__init__(self, **kwargs)
+        LoggingBuildStep.__init__(self, haltOnFailure=haltOnFailure, **kwargs)
 
     def releaseBuildLocks(self):
         self.build.releaseLocks()
@@ -63,10 +63,10 @@ class ShellCommandResumeBuild(ShellCommand):
     description="Resume Build..."
     descriptionDone="Resume Build"
 
-    def __init__(self, resumeBuild=True, resumeSlavepool=None, **kwargs):
+    def __init__(self, resumeBuild=True, resumeSlavepool=None, haltOnFailure=True, **kwargs):
         self.resumeBuild = resumeBuild if resumeBuild is not None else True
         self.resumeSlavepool = "slavenames" if resumeSlavepool is None else resumeSlavepool
-        ShellCommand.__init__(self, **kwargs)
+        ShellCommand.__init__(self, haltOnFailure=haltOnFailure, **kwargs)
 
     def finished(self, results):
         if shouldResumeBuild(self.resumeBuild, results, self.build.steps):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -967,7 +967,7 @@ class FakeBuildRequestsComponent(FakeDBComponent):
             rv.append(self._brdictFromRow(br))
         return defer.succeed(rv)
 
-    def getPrioritizedBuildRequestsInQueue(self, buildername):
+    def getPrioritizedBuildRequestsInQueue(self, buildername, queue=None):
         return self.getBuildRequests(buildername=buildername, complete=False, claimed=False)
 
     def getBuildRequestInQueue(self, buildername, sorted=True):

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -967,7 +967,7 @@ class FakeBuildRequestsComponent(FakeDBComponent):
             rv.append(self._brdictFromRow(br))
         return defer.succeed(rv)
 
-    def getOldestBuildRequestInQueue(self, buildername):
+    def getPrioritizedBuildRequestsInQueue(self, buildername):
         return self.getBuildRequests(buildername=buildername, complete=False, claimed=False)
 
     def getBuildRequestInQueue(self, buildername, sorted=True):

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_BuildRequestDistributor.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_BuildRequestDistributor.py
@@ -244,7 +244,7 @@ class Test(unittest.TestCase):
                 dict(bldr1=dict(priority=20,submitted_at=1448540542),
                      bldr2=None,
                      bldr3=dict(priority=30,submitted_at=1448541047)),
-                ['bldr3', 'bldr1', 'bldr2'])
+                ['bldr3', 'bldr1'])
 
     def test_sortBuilders_custom(self):
         def prioritizeBuilders(master, builders, queue):

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -207,7 +207,7 @@ class KatanaBuildChooserTestCase(unittest.TestCase):
                                                                 property_value='["slave-02", "Force Build Form"]')]
 
         yield self.do_test_maybeStartBuildsOnBuilder(rows=rows,
-                exp_claims=[1, 2], exp_builds=[('slave-01', [2]), ('slave-02', [1])])
+                exp_claims=[1], exp_builds=[('slave-02', [1])])
 
     @defer.inlineCallbacks
     def test_mergePending_CodebasesMatchForceRebuild(self):


### PR DESCRIPTION
- Global priority builds
- Minimize processing (hg slave) latency
- Avoid having the build request distributor try processing builds if there are not pending build requests x or not available slaves for the task
