### PR TITLE
TimedSchedulers use a default priority of 70, it can be also configur…

### DIFF
--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -22,6 +22,7 @@ from twisted.internet import reactor
 from buildbot.util import json
 from buildbot.db import base
 from buildbot.util import epoch2datetime, datetime2epoch
+from buildbot.process.buildrequest import Priority
 
 class BsDict(dict):
     pass
@@ -32,7 +33,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
     def addBuildset(self, sourcestampsetid, reason, properties, triggeredbybrid=None,
                     builderNames=None, external_idstring=None,  _reactor=reactor):
         def thd(conn):
-            priority = 0
+            priority = Priority.Default
             buildsets_tbl = self.db.model.buildsets
             submitted_at = _reactor.seconds()
 
@@ -56,8 +57,7 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
                 if 'priority' in properties:
                     priority_property = properties.get('priority')[0]
                     priority = priority_property if priority_property \
-                                                    and priority_property.isdigit() \
-                                                    and int(priority_property) > 0 else 0
+                                                    and int(priority_property) > 0 else Priority.Default
 
                 inserts = [
                     dict(buildsetid=bsid, property_name=k,

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -23,6 +23,16 @@ from buildbot.status.results import CANCELED, RESUME
 from buildbot.status.buildrequest import BuildRequestStatus
 from buildbot.db import buildrequests
 
+
+class Priority(object):
+    Emergency = 100
+    VeryHigh = 80
+    High =  75
+    TimedScheduler = 70
+    Default = Medium = 50
+    Low = 25
+
+
 class BuildRequest(object):
     """
 

--- a/master/buildbot/schedulers/timed.py
+++ b/master/buildbot/schedulers/timed.py
@@ -23,6 +23,8 @@ from twisted.internet import defer, reactor
 from twisted.python import log
 from buildbot import config
 from buildbot.changes import filter
+from buildbot.process.buildrequest import Priority
+
 # Import croniter if available.
 # This is only required for Nightly schedulers,
 # so fail gracefully if it isn't present.
@@ -41,7 +43,11 @@ class Timed(base.BaseScheduler):
     """
 
     def __init__(self, name, builderNames, properties={}, **kwargs):
-        base.BaseScheduler.__init__(self, name, builderNames, properties, 
+
+        if 'priority' not in properties:
+            properties['priority'] = Priority.TimedScheduler
+
+        base.BaseScheduler.__init__(self, name, builderNames, properties,
                                     **kwargs)
 
         # tracking for when to start the next build

--- a/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_Nightly.py
@@ -23,6 +23,7 @@ from buildbot.schedulers import timed
 from buildbot.test.util import scheduler
 from buildbot.changes import filter
 from buildbot import config
+from buildbot.process.buildrequest import Priority
 
 class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
 
@@ -239,7 +240,8 @@ class Nightly(scheduler.SchedulerMixin, unittest.TestCase):
             self.db.buildsets.assertBuildset(200+i, dict(
                 reason="The Nightly scheduler named 'test' triggered this build",
                 external_idstring=None,
-                properties=[('run_all_slaves', (True, 'Scheduler')),
+                properties=[('priority', (Priority.TimedScheduler, 'Scheduler')),
+                            ('run_all_slaves', (True, 'Scheduler')),
                             ('scheduler', ('test', 'Scheduler')),
                             ('selected_slave', ('slave-0%s' % i, 'Scheduler'))],
                 sourcestampsetid=100+i),

--- a/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
+++ b/master/buildbot/test/unit/test_schedulers_timed_NightlyTriggerable.py
@@ -19,6 +19,7 @@ from buildbot.process import properties
 from buildbot.schedulers import timed
 from buildbot.test.fake import fakedb
 from buildbot.test.util import scheduler
+from buildbot.process.buildrequest import Priority
 
 class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
 
@@ -66,6 +67,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                      ],
                      reason="The NightlyTriggerable scheduler named 'test' triggered this build",
@@ -94,6 +96,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                      ],
                      reason="The NightlyTriggerable scheduler named 'test' triggered this build",
@@ -119,6 +122,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                      ],
                      reason="The NightlyTriggerable scheduler named 'test' triggered this build",
@@ -150,6 +154,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                      ],
                      reason="The NightlyTriggerable scheduler named 'test' triggered this build",
@@ -169,6 +174,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                      ],
                      reason="The NightlyTriggerable scheduler named 'test' triggered this build",
@@ -194,6 +200,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                      ],
                      reason="The NightlyTriggerable scheduler named 'test' triggered this build",
@@ -272,6 +279,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                          ('testprop', ('test', 'TEST')),
                      ],
@@ -298,6 +306,7 @@ class NightlyTriggerable(scheduler.SchedulerMixin, unittest.TestCase):
         self.db.buildsets.assertBuildset('?',
                 dict(external_idstring=None,
                      properties=[
+                         ('priority', (Priority.TimedScheduler, 'Scheduler')),
                          ('scheduler', ('test', 'Scheduler')),
                          ('testprop', ('test', 'TEST')),
                      ],


### PR DESCRIPTION
TimedSchedulers use a default priority of 70, it can be also configured (override per scheduler) passing the property value (properties= {'priority': 10}) below an example:
c['schedulers'].append(Nightly(name='Nightly-MacStandalone2',
branch='trunk',
codebases=getNightlyCodeBases(repositories[unityKey], 'trunk'),
builderNames=[proj1 + "Test GraphicsTests - MacStandalone2"],
hour=14,
minute=24,
properties= {'priority': 10},
onlyIfChanged=False))

Use a default priority of 50 if no specify when adding the buildset