### PR TITLE
Accepting buildbotURL in master.cfg with or without a final slash

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -257,7 +257,13 @@ class MasterConfig(object):
 
         copy_str_param('title', alt_key='projectName')
         copy_str_param('titleURL', alt_key='projectURL')
+
         copy_str_param('buildbotURL')
+
+        # Make sure that buildbotURL ends with a forward slash
+        if not self.buildbotURL.endswith('/'):
+            self.buildbotURL += '/'
+
         copy_str_param('realTimeServer')
         copy_str_param('analytics_code')
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -395,7 +395,11 @@ class MasterConfig_loaders(ConfigErrorsMixin, unittest.TestCase):
         self.do_test_load_global(dict(titleURL='hi'), titleURL='hi')
 
     def test_load_global_buildbotURL(self):
-        self.do_test_load_global(dict(buildbotURL='hey'), buildbotURL='hey')
+        # Make sure that buildbotURL always ends with a forward slash
+        self.do_test_load_global(dict(buildbotURL='hey'), buildbotURL='hey/')
+
+        # Don't change anything if the loaded value already ends with slash
+        self.do_test_load_global(dict(buildbotURL='ho/'), buildbotURL='ho/')
 
     def test_load_global_changeHorizon(self):
         self.do_test_load_global(dict(changeHorizon=10), changeHorizon=10)


### PR DESCRIPTION
Before this change, a buildbotURL without a forward slash at the end would fail
silently, making most links broken without any error being logged.
