### PR TITLE
Bugfix: logout error

### DIFF
--- a/master/buildbot/status/web/loginkatana.py
+++ b/master/buildbot/status/web/loginkatana.py
@@ -59,5 +59,5 @@ class LogoutKatanaResource(LogoutResource):
         s = authz.session(request)
         if s is not None:
             s.expire()
-            request.addCookie(COOKIE_KEY, None, expires=s.getExpiration(), path="/")
+            request.addCookie(COOKIE_KEY, "", expires=s.getExpiration(), path="/")
         return LogoutResource.performAction(self, request)


### PR DESCRIPTION
Fixed:

Error:

exceptions.TypeError: cannot concatenate 'str' and 'NoneType' objects

When trying to logout using auth.HTPasswdAprAuth
