### PR TITLE
Feature/jwt authentication

### DIFF
--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -18,6 +18,7 @@ from twisted.internet.defer import Deferred
 from buildbot.status.web.auth import IAuth
 from buildbot.status.web.session import SessionManager, get_session_manager
 from zope.interface import Interface, implements, Attribute
+import jwt
 
 SESSION_KEY="BuildBotSession"
 
@@ -89,6 +90,9 @@ class JsonWebTokens(object):
 
     def createSessionToken(self, userinfo, user, request, sessions):
         pass
+        token = jwt.encode(payload=userinfo, key=self.key, algorithm=self.algorithm)
+        sessions.addToken(user=user, userinfo=userinfo, token=token)
+        return token
 
     def removeSessionToken(self, request, sessions):
         pass

--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -17,8 +17,91 @@ from twisted.internet import defer
 from twisted.internet.defer import Deferred
 from buildbot.status.web.auth import IAuth
 from buildbot.status.web.session import SessionManager, get_session_manager
+from zope.interface import Interface, implements, Attribute
 
-COOKIE_KEY="BuildBotSession"
+SESSION_KEY="BuildBotSession"
+
+class ISessionHandler(Interface):
+    """
+    Represents a session handler.
+    """
+
+    key = Attribute('key', "Session key")
+    sessions = Attribute('sessions', "Session manager")
+
+    def createSessionToken(self, userinfo, user, request, sessions):
+        """Creates a cookie or JWT token once the user is authenticated"""
+
+    def removeSessionToken(self, request, sessions):
+        """Removes the cookie or JWT token"""
+
+    def validateSessionToken(self, request, sessions):
+        """Validates the cookie or JWT token"""
+
+    def getSession(self, request, sessions):
+        """Return the session object for the request"""
+
+    def logoutSession(self, request, sessions):
+        """Handle the user logout when using cookie or JWT token"""
+
+class BuildbotSession(object):
+    implements(ISessionHandler)
+
+    def __init__(self, key=None, useHttpHeader=False):
+        self.key = key if key else SESSION_KEY
+        self.useHttpHeader = useHttpHeader
+
+    def createSessionToken(self, userinfo, user, request, sessions):
+        cookie, s = sessions.new(user, userinfo)
+        request.addCookie(self.key, cookie, expires=s.getExpiration(),path="/")
+        request.received_cookies = {self.key: cookie}
+        return cookie
+
+    def removeSessionToken(self, request, sessions):
+        if self.key in request.received_cookies:
+            cookie = request.received_cookies[self.key]
+            sessions.remove(cookie)
+
+    def getSession(self, request, sessions):
+        if self.key in request.received_cookies:
+            cookie = request.received_cookies[self.key]
+            return sessions.get(cookie)
+        return None
+
+    def validateSessionToken(self, request, sessions):
+        if self.useHttpHeader:
+            return request.getUser() != ''
+
+        return self.getSession(request, sessions) is not None
+
+    def logoutSession(self, request, sessions):
+        session = self.getSession(request, sessions)
+        if session is not None:
+            session.expire()
+            request.addCookie(self.key, None, expires=session.getExpiration(), path="/")
+
+class JsonWebTokens(object):
+    implements(ISessionHandler)
+
+    def __init__(self, key=None, algorithm='HS256'):
+        self.key = self.key = key if key else SESSION_KEY
+        self.algorithm = algorithm
+
+    def createSessionToken(self, userinfo, user, request, sessions):
+        pass
+
+    def removeSessionToken(self, request, sessions):
+        pass
+
+    def validateSessionToken(self, request, sessions):
+        pass
+
+    def getSession(self, request, sessions):
+        pass
+
+    def logoutSession(self, request, sessions):
+        pass
+
 class Authz(object):
     """Decide who can do what."""
 
@@ -44,11 +127,13 @@ class Authz(object):
     }
 
     def __init__(self,
-            default_action=False,
-            auth=None,
-            useHttpHeader=False,
-            httpLoginUrl=False,
-            **kwargs):
+                 default_action=False,
+                 auth=None,
+                 useHttpHeader=False,
+                 httpLoginUrl=False,
+                 sessionHandler=None,
+                 **kwargs):
+
         self.auth = auth
         if auth:
             assert IAuth.providedBy(auth)
@@ -66,16 +151,18 @@ class Authz(object):
         if kwargs:
             raise ValueError("unknown authorization action(s) " + ", ".join(kwargs.keys()))
 
+        self.sessionHandler = sessionHandler if sessionHandler is not None \
+            else BuildbotSession(useHttpHeader=useHttpHeader)
+        assert ISessionHandler.providedBy(self.sessionHandler)
+
     def session(self, request):
-        if COOKIE_KEY in request.received_cookies:
-            cookie = request.received_cookies[COOKIE_KEY]
-            return self.sessions.get(cookie)
-        return None
-            
+        return self.sessionHandler.getSession(request, self.sessions)
+
+    def logoutUser(self, request):
+        self.sessionHandler.logoutSession(request=request, sessions=self.sessions)
+
     def authenticated(self, request):
-        if self.useHttpHeader:
-            return request.getUser() != ''
-        return self.session(request) != None
+        return self.sessionHandler.validateSessionToken(request, self.sessions)
 
     def getUserInfo(self, user):
         if self.useHttpHeader:
@@ -202,19 +289,19 @@ class Authz(object):
             return defer.succeed(False)
         d = defer.maybeDeferred(self.auth.authenticate, user, passwd)
 
-        def create_cookie(infos):
-            cookie, s = self.sessions.new(user, infos)
-            request.addCookie(COOKIE_KEY, cookie, expires=s.getExpiration(),path="/")
-            request.received_cookies = {COOKIE_KEY:cookie}
-            return cookie
-
         def check_authenticate(res):
             if res:
                 infos = self.auth.getUserInfo(user)
                 if isinstance(infos, Deferred):
-                    return infos.addBoth(create_cookie)
+                    return infos.addBoth(self.sessionHandler.createSessionToken,
+                                         user=user,
+                                         request=request,
+                                         sessions=self.sessions)
                 else:
-                    return create_cookie(infos)
+                    return self.sessionHandler.createSessionToken(userinfo=infos,
+                                                                  user=user,
+                                                                  request=request,
+                                                                  sessions=self.sessions)
             else:
                 return False
 
@@ -222,6 +309,4 @@ class Authz(object):
         return d
 
     def logout(self, request):
-        if COOKIE_KEY in request.received_cookies:
-            cookie = request.received_cookies[COOKIE_KEY]
-            self.sessions.remove(cookie)
+        self.sessionHandler.removeSessionToken(request=request, sessions=self.sessions)

--- a/master/buildbot/status/web/loginkatana.py
+++ b/master/buildbot/status/web/loginkatana.py
@@ -1,6 +1,5 @@
 from twisted.internet import defer
 from buildbot.status.web.auth import LogoutResource
-from buildbot.status.web.authz import COOKIE_KEY
 from buildbot.status.web.base import HtmlResource, ActionResource, \
     path_to_login, path_to_authenticate, path_to_root, path_to_authfail
 import urllib
@@ -55,9 +54,5 @@ class AuthenticateActionResource(ActionResource):
 class LogoutKatanaResource(LogoutResource):
 
     def performAction(self, request):
-        authz = self.getAuthz(request)
-        s = authz.session(request)
-        if s is not None:
-            s.expire()
-            request.addCookie(COOKIE_KEY, None, expires=s.getExpiration(), path="/")
+        self.getAuthz(request).logoutUser(request)
         return LogoutResource.performAction(self, request)

--- a/master/buildbot/status/web/loginkatana.py
+++ b/master/buildbot/status/web/loginkatana.py
@@ -34,7 +34,7 @@ class  AuthenticateApiActionResource(ActionResource):
 
     def render(self, request):
         d = defer.maybeDeferred(lambda : self.performAction(request))
-        def redirect(token):
+        def send(token):
             response = '{%s}' % token if token else "{}"
             request.setHeader("content-type", "application/json")
             request.write(response)
@@ -42,7 +42,7 @@ class  AuthenticateApiActionResource(ActionResource):
                 request.finish()
             except RuntimeError:
                 log.msg("http client disconnected before results were sent")
-        d.addCallback(redirect)
+        d.addCallback(send)
 
         def fail(f):
             request.processingFailed(f)

--- a/master/buildbot/status/web/session.py
+++ b/master/buildbot/status/web/session.py
@@ -107,9 +107,9 @@ class SessionManager(object):
         cookie = generate_cookie()
         return cookie, self.addToken(cookie, infos)
 
-    def addToken(self, token, infos):
-        user = infos["userName"]
-        self.users[user] = self.sessions[token] = s = Session(user, infos)
+    def addToken(self, token, userinfo):
+        user = userinfo["userName"]
+        self.users[user] = self.sessions[token] = s = Session(user, userinfo)
         self.saveYourself()
         return s
 

--- a/master/buildbot/status/web/session.py
+++ b/master/buildbot/status/web/session.py
@@ -105,10 +105,13 @@ class SessionManager(object):
         
     def new(self, user, infos):
         cookie = generate_cookie()
+        return cookie, self.addToken(cookie, infos)
+
+    def addToken(self, token, infos):
         user = infos["userName"]
-        self.users[user] = self.sessions[cookie] = s = Session(user, infos)
+        self.users[user] = self.sessions[token] = s = Session(user, infos)
         self.saveYourself()
-        return cookie, s
+        return s
 
     def gc(self):
         """remove old cookies"""

--- a/master/setup.py
+++ b/master/setup.py
@@ -202,7 +202,8 @@ else:
         'python-ldap >= 2.4.25',
         'mysql-python',
         # alternative MySQL driver, that works under pypy
-        'pymysql==0.7.1'
+        'pymysql==0.7.1',
+        'PyJWT==1.4.0'
     ]
     setup_args['tests_require'] = [
         'mock',


### PR DESCRIPTION
- Add sessionHandler so we are able to switch between buildbot's default and JWT 
- Add Authentication API for future work (katana new UI, decouple from master)
- Fixes a bug in authentication (when user has been already authenticated and has valid cookie)
