### PR TITLE
Hotfixes/bugs 2.1.x

### DIFF
--- a/master/buildbot/buildslave/__init__.py
+++ b/master/buildbot/buildslave/__init__.py
@@ -242,12 +242,18 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
         yield config.ReconfigurableServiceMixin.reconfigService(self,
                                                             new_config)
 
+    @defer.inlineCallbacks
     def stopService(self):
+        # TODO: This should be removed when the slave information is persisted
+        if self.slave_status.isPaused():
+            log.msg("Warning: slave '%s' is paused, will disconnect" % self.slave_status.name)
+            yield self.shutdown()
+
         if self.registration:
             self.registration.unregister()
             self.registration = None
         self.stopMissingTimer()
-        return service.MultiService.stopService(self)
+        yield service.MultiService.stopService(self)
 
     def findNewSlaveInstance(self, new_config):
         # TODO: called multiple times per reconfig; use 1-element cache?

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -976,6 +976,15 @@ class IStatusReceiver(Interface):
     def slaveDisconnected(slaveName):
         """The slave has disconnected."""
 
+    def slavePaused(slavename, user):
+        """The slave has been paused."""
+
+    def slaveUnpaused(slavename, user):
+        """The slave has been Unpaused."""
+
+    def slaveShutdownGraceFully(slavename, user):
+        """The slave has been shut down gracefully."""
+
     def checkConfig(otherStatusReceivers):
         """Verify that there are no other status receivers which conflict with
         the current one.

--- a/master/buildbot/interfaces.py
+++ b/master/buildbot/interfaces.py
@@ -976,13 +976,13 @@ class IStatusReceiver(Interface):
     def slaveDisconnected(slaveName):
         """The slave has disconnected."""
 
-    def slavePaused(slavename, user):
+    def slavePaused(slavename, url, user):
         """The slave has been paused."""
 
-    def slaveUnpaused(slavename, user):
+    def slaveUnpaused(slavename, url, user):
         """The slave has been Unpaused."""
 
-    def slaveShutdownGraceFully(slavename, user):
+    def slaveShutdownGraceFully(slavename, url, user):
         """The slave has been shut down gracefully."""
 
     def checkConfig(otherStatusReceivers):

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -82,6 +82,9 @@ class BuildRequest(object):
     source = None
     sources = None
     submittedAt = None
+    brdict = None
+    checkMerges = True
+    retries = 0
 
     @classmethod
     def fromBrdict(cls, master, brdict):

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -83,13 +83,13 @@ class StatusReceiverBase:
     def slaveDisconnected(self, slaveName):
         pass
 
-    def slavePaused(self, slavename, user):
+    def slavePaused(self, slavename, url, user):
         pass
 
-    def slaveUnpaused(self, slavename, user):
+    def slaveUnpaused(self, slavename, url, user):
         pass
 
-    def slaveShutdownGraceFully(self, slavename, user):
+    def slaveShutdownGraceFully(self, slavename, url, user):
         pass
 
     def checkConfig(self, otherStatusReceivers):

--- a/master/buildbot/status/base.py
+++ b/master/buildbot/status/base.py
@@ -83,6 +83,15 @@ class StatusReceiverBase:
     def slaveDisconnected(self, slaveName):
         pass
 
+    def slavePaused(self, slavename, user):
+        pass
+
+    def slaveUnpaused(self, slavename, user):
+        pass
+
+    def slaveShutdownGraceFully(self, slavename, user):
+        pass
+
     def checkConfig(self, otherStatusReceivers):
         pass
 

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -523,20 +523,20 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
             if hasattr(t, 'slaveDisconnected'):
                 t.slaveDisconnected(name)
 
-    def slavePaused(self, slavename, user):
+    def slavePaused(self, slavename, url, user):
         for t in self.watchers:
             if hasattr(t, 'slavePaused'):
-                t.slavePaused(slavename, user)
+                t.slavePaused(slavename, url, user)
 
-    def slaveUnpaused(self, slavename, user):
+    def slaveUnpaused(self, slavename, url, user):
         for t in self.watchers:
             if hasattr(t, 'slaveUnpaused'):
-                t.slaveUnpaused(slavename, user)
+                t.slaveUnpaused(slavename, url, user)
 
-    def slaveShutdownGraceFully(self, slavename, user):
+    def slaveShutdownGraceFully(self, slavename, url, user):
         for t in self.watchers:
             if hasattr(t, 'slaveShutdownGraceFully'):
-                t.slaveShutdownGraceFully(slavename, user)
+                t.slaveShutdownGraceFully(slavename, url, user)
 
     def changeAdded(self, change):
         for t in self.watchers:

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -523,6 +523,21 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
             if hasattr(t, 'slaveDisconnected'):
                 t.slaveDisconnected(name)
 
+    def slavePaused(self, slavename, user):
+        for t in self.watchers:
+            if hasattr(t, 'slavePaused'):
+                t.slavePaused(slavename, user)
+
+    def slaveUnpaused(self, slavename, user):
+        for t in self.watchers:
+            if hasattr(t, 'slaveUnpaused'):
+                t.slaveUnpaused(slavename, user)
+
+    def slaveShutdownGraceFully(self, slavename, user):
+        for t in self.watchers:
+            if hasattr(t, 'slaveShutdownGraceFully'):
+                t.slaveShutdownGraceFully(slavename, user)
+
     def changeAdded(self, change):
         for t in self.watchers:
             if hasattr(t, 'changeAdded'):

--- a/master/buildbot/status/status_push.py
+++ b/master/buildbot/status/status_push.py
@@ -331,6 +331,15 @@ class StatusPush(StatusReceiverMultiService):
     def slaveDisconnected(self, slavename):
         self.push('slaveDisconnected', slavename=slavename)
 
+    def slavePaused(self, slavename, user):
+        self.push('slavePaused', slavename=slavename, user=user)
+
+    def slaveUnpaused(self, slavename, user):
+        self.push('slaveUnpaused', slavename=slavename, user=user)
+
+    def slaveShutdownGraceFully(self, slavename, user):
+        self.push('slaveShutdownGraceFully', slavename=slavename, user=user)
+
 
 class HttpStatusPush(StatusPush):
     """Event streamer to a HTTP server."""
@@ -652,6 +661,15 @@ class AutobahnStatusPush(StatusPush):
 
     def slaveDisconnected(self, slavename):
         self.push('slaveDisconnected', slavename=slavename)
+
+    def slavePaused(self, slavename, user):
+        self.push('slavePaused', slavename=slavename, user=user)
+
+    def slaveUnpaused(self, slavename, user):
+        self.push('slaveUnpaused', slavename=slavename, user=user)
+
+    def slaveShutdownGraceFully(self, slavename, user):
+        self.push('slaveShutdownGraceFully', slavename=slavename, user=user)
 
     def logStarted(self, build, step, log):
         #We don't need this event yet

--- a/master/buildbot/status/status_push.py
+++ b/master/buildbot/status/status_push.py
@@ -331,14 +331,14 @@ class StatusPush(StatusReceiverMultiService):
     def slaveDisconnected(self, slavename):
         self.push('slaveDisconnected', slavename=slavename)
 
-    def slavePaused(self, slavename, user):
-        self.push('slavePaused', slavename=slavename, user=user)
+    def slavePaused(self, slavename, url, user):
+        self.push('slavePaused', slavename=slavename, url=url, user=user)
 
-    def slaveUnpaused(self, slavename, user):
-        self.push('slaveUnpaused', slavename=slavename, user=user)
+    def slaveUnpaused(self, slavename, url, user):
+        self.push('slaveUnpaused', slavename=slavename, url=url, user=user)
 
-    def slaveShutdownGraceFully(self, slavename, user):
-        self.push('slaveShutdownGraceFully', slavename=slavename, user=user)
+    def slaveShutdownGraceFully(self, slavename, url, user):
+        self.push('slaveShutdownGraceFully', slavename=slavename, url=url, user=user)
 
 
 class HttpStatusPush(StatusPush):
@@ -662,14 +662,14 @@ class AutobahnStatusPush(StatusPush):
     def slaveDisconnected(self, slavename):
         self.push('slaveDisconnected', slavename=slavename)
 
-    def slavePaused(self, slavename, user):
-        self.push('slavePaused', slavename=slavename, user=user)
+    def slavePaused(self, slavename, url, user):
+        self.push('slavePaused', slavename=slavename, url=url, user=user)
 
-    def slaveUnpaused(self, slavename, user):
-        self.push('slaveUnpaused', slavename=slavename, user=user)
+    def slaveUnpaused(self, slavename, url, user):
+        self.push('slaveUnpaused', slavename=slavename, url=url, user=user)
 
-    def slaveShutdownGraceFully(self, slavename, user):
-        self.push('slaveShutdownGraceFully', slavename=slavename, user=user)
+    def slaveShutdownGraceFully(self, slavename, url, user):
+        self.push('slaveShutdownGraceFully', slavename=slavename, url=url, user=user)
 
     def logStarted(self, build, step, log):
         #We don't need this event yet

--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -272,10 +272,14 @@ def path_to_step(request, stepstatus, codebases = True):
     return (path_to_build(request, stepstatus.getBuild(), False) +
             "/steps/%s" % urllib.quote(stepstatus.getName(), safe='') + codebases_arg)
 
+def absolute_path_to_slave(status, slave):
+    return slave_path(status.getBuildbotURL(), slave)
+
 def path_to_slave(request, slave):
-    return (path_to_root(request) +
-            "buildslaves/" +
-            urllib.quote(slave.getName(), safe=''))
+    return slave_path(path_to_root(request), slave)
+
+def slave_path(root, slave):
+    return root + "buildslaves/" + urllib.quote(slave.getName(), safe='')
 
 def path_to_change(request, change):
     return (path_to_root(request) +

--- a/master/buildbot/status/web/slaves.py
+++ b/master/buildbot/status/web/slaves.py
@@ -38,8 +38,9 @@ class ShutdownActionResource(ActionResource):
 
         url = None
         if res:
-            name = authz.getUsernameFull(request)
-            log.msg("Shutdown %s gracefully requested by %s" % (self.slave.name, name))
+            username = authz.getUsernameFull(request)
+            log.msg("Shutdown %s gracefully requested by %s" % (self.slave.name, username))
+            self.slave.master.status.slaveShutdownGraceFully(self.slave.name, username)
             self.slave.setGraceful(True)
             url = path_to_slave(request, self.slave)
         else:
@@ -61,9 +62,14 @@ class PauseActionResource(ActionResource):
 
         url = None
         if res:
-            name = authz.getUsernameFull(request)
-            action = "Unpause" if self.slave.isPaused() else "Pause"
-            log.msg("%s %s requested by %s" % (action, self.slave.name, name))
+            username = authz.getUsernameFull(request)
+            if self.slave.isPaused():
+                self.slave.master.status.slaveUnpaused(self.slave.name, username)
+                action = "Unpause"
+            else:
+                self.slave.master.status.slavePaused(self.slave.name, username)
+                action = "Pause"
+            log.msg("%s %s requested by %s" % (action, self.slave.name, username))
             self.slave.setPaused(self.state)
             url = path_to_slave(request, self.slave)
         else:

--- a/master/buildbot/status/web/slaves.py
+++ b/master/buildbot/status/web/slaves.py
@@ -22,8 +22,8 @@ from twisted.web.util import Redirect
 from twisted.web.resource import NoResource
 from buildbot.status.web.base import HtmlResource, \
     BuildLineMixin, ActionResource, path_to_slave, path_to_authzfail, path_to_json_slaves, \
-    path_to_json_past_slave_builds
-from buildbot.status.web.status_json import SlavesJsonResource, FilterOut, PastBuildsJsonResource, SlaveJsonResource
+    path_to_json_past_slave_builds, absolute_path_to_slave
+from buildbot.status.web.status_json import FilterOut, PastBuildsJsonResource, SlaveJsonResource
 
 
 class ShutdownActionResource(ActionResource):
@@ -39,8 +39,9 @@ class ShutdownActionResource(ActionResource):
         url = None
         if res:
             username = authz.getUsernameFull(request)
+            slave_url = absolute_path_to_slave(self.slave.master.status, self.slave)
             log.msg("Shutdown %s gracefully requested by %s" % (self.slave.name, username))
-            self.slave.master.status.slaveShutdownGraceFully(self.slave.name, username)
+            self.slave.master.status.slaveShutdownGraceFully(self.slave.name, slave_url, username)
             self.slave.setGraceful(True)
             url = path_to_slave(request, self.slave)
         else:
@@ -63,11 +64,12 @@ class PauseActionResource(ActionResource):
         url = None
         if res:
             username = authz.getUsernameFull(request)
+            slave_url = absolute_path_to_slave(self.slave.master.status, self.slave)
             if self.slave.isPaused():
-                self.slave.master.status.slaveUnpaused(self.slave.name, username)
+                self.slave.master.status.slaveUnpaused(self.slave.name, slave_url, username)
                 action = "Unpause"
             else:
-                self.slave.master.status.slavePaused(self.slave.name, username)
+                self.slave.master.status.slavePaused(self.slave.name, slave_url, username)
                 action = "Pause"
             log.msg("%s %s requested by %s" % (action, self.slave.name, username))
             self.slave.setPaused(self.state)

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -616,6 +616,27 @@ class TestKatanaBuildRequestDistributorMaybeStartBuildsOn(KatanaBuildRequestDist
         self.quiet_deferred.addCallback(check)
         return self.quiet_deferred
 
+    @defer.inlineCallbacks
+    def test_maybeStartOrResumeBuildsOnUnclaimedQueueFailsToSelectSlave(self):
+        self.setupBuilderInMaster(name='bldr1', slavenames={'slave-01': True}, addRunningBuilds=True)
+        self.initialized()
+        yield self.generateNewBuilds()
+        self.brd.katanaBuildChooser._popNextSlave = lambda : defer.succeed(None)
+        self.brd.katanaBuildChooser.getSelectedSlaveFromBuildRequest = lambda breq: None
+        yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
+        self.assertEquals(self.processedBuilds, [])
+
+    @defer.inlineCallbacks
+    def test_maybeStartOrResumeBuildsOnBuildChooserFailsToSelectSlave(self):
+        self.setupBuilderInMaster(name='bldr1', slavenames={'slave-01': True}, addRunningBuilds=True)
+        self.initialized()
+        yield self.generateNewBuilds()
+        self.brd.katanaBuildChooser._popNextSlave = lambda : defer.succeed(None)
+        #self.brd.katanaBuildChooser.getSelectedSlaveFromBuildRequest = lambda breq: None
+        yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
+        print self.processedBuilds
+        # self.assertTrue(self.processedBuilds, [('slave-02', [12])])
+
 
 class TestKatanaBuildChooser(KatanaBuildRequestDistributorTestSetup, unittest.TestCase):
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -631,11 +631,18 @@ class TestKatanaBuildRequestDistributorMaybeStartBuildsOn(KatanaBuildRequestDist
         self.setupBuilderInMaster(name='bldr1', slavenames={'slave-01': True}, addRunningBuilds=True)
         self.initialized()
         yield self.generateNewBuilds()
-        self.brd.katanaBuildChooser._popNextSlave = lambda : defer.succeed(None)
-        #self.brd.katanaBuildChooser.getSelectedSlaveFromBuildRequest = lambda breq: None
+        self.brd.katanaBuildChooser.getSelectedSlaveFromBuildRequest = lambda breq: None
         yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
-        print self.processedBuilds
-        # self.assertTrue(self.processedBuilds, [('slave-02', [12])])
+        self.assertEquals(self.processedBuilds, [('slave-01', [1, 2, 3, 4, 5])])
+
+    @defer.inlineCallbacks
+    def test_maybeStartOrResumeBuildsOnBuildChooserFailsToPickUpSlave(self):
+        self.setupBuilderInMaster(name='bldr1', slavenames={'slave-01': True}, addRunningBuilds=True)
+        self.initialized()
+        yield self.generateNewBuilds()
+        self.brd.katanaBuildChooser._pickUpSlave = lambda slave, breq: None
+        yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
+        self.assertEquals(self.processedBuilds, [('slave-01', [8])])
 
 
 class TestKatanaBuildChooser(KatanaBuildRequestDistributorTestSetup, unittest.TestCase):


### PR DESCRIPTION
1. Add status push when the slaves are Paused or Disconnected from katana
2. Fix the issue that katana keeps retrying a build and with a slave that turns out to be not usable
