### PR TITLE
Fix pip www setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - if [ "$TEST_TARGET" = "javascript" ]; then export TZ=Europe/Copenhagen; fi
 
 install:
+  - if [ "$TEST_TARGET" != "javascript" ]; then pip install -e www; fi
   - if [ "$TEST_TARGET" != "javascript" ]; then pip install -e $TEST_TARGET --process-dependency-links; fi
   - if [ "$TEST_TARGET" != "javascript" ]; then pip install -v mock; fi
   - if [ "$TEST_TARGET" != "javascript" ]; then pip install -v pyflakes; fi

--- a/master/setup.py
+++ b/master/setup.py
@@ -116,7 +116,6 @@ setup_args = {
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Testing',
     ],
-    'package_dir': {'www': '../www'},
     'packages': ["buildbot",
                  "buildbot.status", "buildbot.status.web", "buildbot.status.web.hooks",
                  "buildbot.changes",
@@ -139,7 +138,7 @@ setup_args = {
                  "buildbot.test.fake",
                  "buildbot.test.unit",
                  "buildbot.test.util",
-                 "buildbot.test.regressions", "www"
+                 "buildbot.test.regressions"
                  ],
     'data_files': [
         ("buildbot", [
@@ -153,15 +152,6 @@ setup_args = {
             "buildbot/clients/debug.glade",
         ]),
         include("buildbot/status/web/files/", '*.png'),
-        include("www/fonts/katana_icons", '*', package_path="../www/fonts/katana_icons"),
-        include("www/fonts/leckerlione", '*', package_path="../www/fonts/leckerlione"),
-        include("www/fonts/pacifico", '*', package_path="../www/fonts/pacifico"),
-        include("www/images", '*', package_path="../www/images"),
-        include("www/prod/css", '*', package_path="../www/prod/css"),
-        include("www/prod/script", '*', package_path="../www/prod/script"),
-        ("www", ["../www/favicon.ico", "../www/robots.txt", "../www/templates_readme.txt"]),
-        include("www/templates", '*.html', package_path="../www/templates"),
-        include("www/templates", '*.xml', package_path="../www/templates"),
         ("buildbot/scripts", [
             "buildbot/scripts/sample.cfg",
             "buildbot/scripts/buildbot_tac.tmpl",

--- a/master/setup.py
+++ b/master/setup.py
@@ -198,7 +198,8 @@ else:
         # alternative MySQL driver, that works under pypy
         'pymysql == 0.7.1',
         'PyJWT == 1.4.0',
-        'pynats == 0.0.1'
+        'pynats == 0.0.1',
+        'www'
     ]
     setup_args['tests_require'] = [
         'mock == 1.3.0',

--- a/www/MANIFEST.in
+++ b/www/MANIFEST.in
@@ -1,0 +1,9 @@
+include favicon.ico
+include robots.txt
+include templates_readme.txt
+recursive-include fonts *
+recursive-include images *
+recursive-include prod/css *
+recursive-include prod/script *
+recursive-include templates *.xml
+recursive-include templates *.html

--- a/www/setup.py
+++ b/www/setup.py
@@ -28,6 +28,9 @@ setup_args = {
     'long_description': "JavaScript frontend for katana",
     'package_dir': {'www': ''},
     'packages': ["www"],
+    # This makes it include all files from MANIFEST.in
+    # It also needs a newer version of setuptools than 17.1
+    # which has a bug when dealing with MANIFEST.in
     'include_package_data': True
 }
 

--- a/www/setup.py
+++ b/www/setup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+"""
+Standard setup script.
+"""
+
+from distutils.core import setup
+
+
+setup_args = {
+    'name': "www",
+    'description': "Katana frontend",
+    'long_description': "JavaScript frontend for katana",
+    'package_dir': {'www': ''},
+    'packages': ["www"],
+    'include_package_data': True
+}
+
+setup(**setup_args)
+
+# Local Variables:
+# fill-column: 71
+# End:


### PR DESCRIPTION
This should work this time.
I moved extracted the setup logic for the www folder into its own setup.py file.
It uses the MANIFEST.in file to include various files, this is broken on setuptools 17, so this needs a newer version. I have tested it with 21.2.2.
Now to install you do
- `pip install www/`
- `pip install master/ --process-dependency-links`
