### PR TITLE
Feature/json pending builds

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -424,6 +424,8 @@ class Build(properties.PropertiesMixin):
         if len(self.requests) > 0:
             self.build_status.setSubmitted(self.requests[0].submittedAt)
             self.setProperty("submittedTime", self.requests[0].submittedAt, "buildrequest")
+            self.build_status.setBuildRequestID(self.requests[0].id)
+            self.setProperty("buildRequestID", self.requests[0].id, "buildrequest")
             self.build_status.setBuildChainID(self.requests[0].buildChainID)
             self.setProperty("buildChainID", self.requests[0].buildChainID, "buildrequest")
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -107,7 +107,7 @@ class Builder(config.ReconfigurableServiceMixin,
         self.builder_status.setCategory(builder_config.category)
         self.builder_status.setSlavenames(self.config.slavenames)
         self.builder_status.setStartSlavenames(self.config.startSlavenames)
-        self.builder_status.setCacheSize(new_config.caches['Builds'])
+        self.builder_status.setCacheSize(new_config.caches)
         self.builder_status.setProject(builder_config.project)
         self.builder_status.setFriendlyName(builder_config.friendly_name)
         self.builder_status.setTags(builder_config.tags)

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -50,6 +50,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
     submitted = None
     owners = None
     buildChainID = None
+    buildRequestID = None
     currentStep = None
     text = []
     results = None
@@ -309,6 +310,9 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
 
     def setBuildChainID(self, buildChainID):
         self.buildChainID = buildChainID
+
+    def setBuildRequestID(self, buildRequestID):
+        self.buildRequestID = buildRequestID
 
     def setOwners(self, owners):
         self.owners = owners
@@ -613,6 +617,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         result['reason'] = self.getReason()
         result['submittedTime'] = self.submitted
         result['owners'] = self.owners
+        result['buildRequestID'] = self.buildRequestID
         result['buildChainID'] = self.buildChainID
         result['blame'] = self.getResponsibleUsers()
         result['url'] = status.getURLForThing(self)

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -1017,7 +1017,7 @@ class PendingBuildsCache():
         self.builder = builder
         self.buildRequestStatusCodebasesCache = {}
         self.buildRequestStatusCodebasesDictsCache = {}
-        self.buildRequestStatusCache = LRUCache(BuildRequestStatus.createBuildRequestStatus, 200)
+        self.buildRequestStatusCache = LRUCache(BuildRequestStatus.createBuildRequestStatus, 50)
         self.cache_now()
         self.builder.subscribe(self)
 

--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -27,6 +27,7 @@ class BuildRequestStatus:
         self.brid = brid
         self.status = status
         self.master = status.master
+        self.dict = {}
 
         self._buildrequest = None
         self._buildrequest_lock = defer.DeferredLock()
@@ -206,5 +207,4 @@ class BuildRequestStatus:
         result['builds'] = sorted_builds
         result['lastBuildNumber'] = sorted_builds[0]['number'] if sorted_builds and len(sorted_builds) > 0 \
                                                                   and 'number' in sorted_builds[0] else None
-
         defer.returnValue(result)

--- a/master/buildbot/status/buildrequest.py
+++ b/master/buildbot/status/buildrequest.py
@@ -173,7 +173,7 @@ class BuildRequestStatus:
         return result
 
     @defer.inlineCallbacks
-    def asDict_async(self, request=None):
+    def asDict_async(self, codebases={}):
         result = {}
         builder = self.status.getBuilder(self.getBuilderName())
         if not builder:
@@ -197,9 +197,9 @@ class BuildRequestStatus:
         result['builderFriendlyName'] = builder.getFriendlyName()
         result['builderURL'] = self.status.getURLForThing(builder)
 
-        if request is not None:
-            from buildbot.status.web.base import getCodebasesArg
-            result['builderURL'] += getCodebasesArg(request)
+        if codebases:
+            from buildbot.status.web.base import getCodeBasesURLParam
+            result['builderURL'] += getCodeBasesURLParam(codebases=codebases)
 
         builds = yield self.getBuilds()
         all_builds = [build.asDict() for build in builds]

--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -146,6 +146,15 @@ def path_to_buildqueue(request):
 def path_to_buildqueue_json(request):
     return path_to_root(request) + "json/buildqueue"
 
+def getCodebases(request=None):
+    # just return the selected codebases
+    codebases = {}
+    if request is not None:
+        for key, val in request.args.iteritems():
+            if '_branch' in key:
+                codebases[key[0:key.find('_')]] = ''.join(val)
+
+    return codebases
 
 def getCodebasesArg(request=None, codebases={}, sourcestamps=None):
     codebases_arg=''

--- a/master/buildbot/status/web/base.py
+++ b/master/buildbot/status/web/base.py
@@ -156,17 +156,27 @@ def getCodebases(request=None):
 
     return codebases
 
+
+def add_url_param(url, key, val):
+    if len(url) > 0:
+        url += "&"
+    else:
+        url += "?"
+
+    url += "%s=%s" % (key, ''.join(val))
+    return url
+
+def getBranchNameUrlParam(branch):
+    return urllib.quote(branch, safe='') + "_branch"
+
+def getCodeBasesURLParam(codebases):
+    args=''
+    for key, val in codebases.iteritems():
+        args = add_url_param(args, getBranchNameUrlParam(branch=key), val)
+    return args
+
 def getCodebasesArg(request=None, codebases={}, sourcestamps=None):
     codebases_arg=''
-
-    def add_url_param(url, key, val):
-        if len(url) > 0:
-            url += "&"
-        else:
-            url += "?"
-
-        url += "%s=%s" % (key, ''.join(val))
-        return url
 
     if request is not None:
         for key, val in request.args.iteritems():

--- a/master/buildbot/status/web/projects.py
+++ b/master/buildbot/status/web/projects.py
@@ -17,7 +17,8 @@ import copy
 import json
 from operator import attrgetter
 
-from buildbot.status.web.base import HtmlResource, path_to_codebases, path_to_json_builders, path_to_comparison
+from buildbot.status.web.base import HtmlResource, path_to_codebases, path_to_json_builders, path_to_comparison, \
+    getBranchNameUrlParam
 from buildbot.status.web.builder import BuildersResource
 from buildbot import util
 from twisted.internet import defer
@@ -52,11 +53,11 @@ class ProjectsResource(HtmlResource):
             for cb in value.codebases:
                 if '?' not in project_path:
                     project_path += '?'
-                for cbkey,cbvalue in cb.iteritems():
+                for cbkey, cbvalue in cb.iteritems():
                     if '=' in project_path:
                         project_path += "&"
 
-                    project_path += urllib.quote(cbkey, safe='') + "_branch"
+                    project_path += getBranchNameUrlParam(cbkey)
 
                     if 'defaultbranch' in cbvalue.keys():
                         branch =  cbvalue['defaultbranch']

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -427,13 +427,7 @@ class BuilderPendingBuildsJsonResource(JsonResource):
 
     def asDict(self, request):
         # buildbot.status.builder.BuilderStatus
-        d = self.builder_status.getPendingBuildRequestStatuses(codebases=getCodebases(request=request))
-
-        def to_dict(statuses):
-            return defer.gatherResults(
-                [b.asDict_async() for b in statuses])
-
-        d.addCallback(to_dict)
+        d = self.builder_status.getPendingBuildRequestStatusesDicts(codebases=getCodebases(request=request))
         return d
 
 
@@ -990,15 +984,8 @@ class SinglePendingBuildsJsonResource(JsonResource):
         getCodebasesArg(request=request, codebases=codebases)
 
         # Get pending request filtered + sorted
-        builds = yield self.builder.getPendingBuildRequestStatuses(codebases=codebases)
-
-        #Convert to dictionary
-        output = []
-        for b in builds:
-            d = yield b.asDict_async(request)
-            output.append(d)
-
-        defer.returnValue(output)
+        pendingBuilds = yield self.builder.getPendingBuildRequestStatusesDicts(codebases=codebases)
+        defer.returnValue(pendingBuilds)
 
 
 class SlaveBuildsJsonResource(JsonResource):

--- a/master/buildbot/test/regressions/test_shell_command_properties.py
+++ b/master/buildbot/test/regressions/test_shell_command_properties.py
@@ -57,6 +57,9 @@ class FakeBuildStatus:
     def setBuildChainID(self, buildChainID):
         self.buildChainID = buildChainID
 
+    def setBuildRequestID(self, buildRequestID):
+        self.buildRequestID = buildRequestID
+
     def setOwners(self, owners):
         self.owners = owners
 
@@ -80,6 +83,7 @@ class FakeStepStatus:
 
 class FakeBuildRequest:
     def __init__(self, reason, sources, buildername):
+        self.id = None
         self.reason = reason
         self.sources = sources
         self.buildername = buildername

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -50,6 +50,7 @@ class FakeSource:
 
 class FakeRequest:
     def __init__(self):
+        self.id = None
         self.sources = []
         self.reason = "Because"
         self.properties = Properties()

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -505,7 +505,7 @@ class TestSinglePendingBuildsJsonResource(unittest.TestCase):
             requests = [1, 2, 3]
             return [getBuildRequestStatus(id) for id in requests]
 
-        builder.builder_status.fetchPendingBuildRequestStatuses = fetchPendingBuildRequestStatuses
+        builder.builder_status.pendingBuildCache.fetchPendingBuildRequestStatuses = fetchPendingBuildRequestStatuses
 
         pending_json = status_json.SinglePendingBuildsJsonResource(self.master_status, builder.builder_status)
         pending_dict = yield pending_json.asDict(self.request)

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -90,7 +90,7 @@ def mockBuilder(master, master_status, buildername, proj):
     builder.builder_status.setTags(['tag1', 'tag2'])
     builder.builder_status.status = master_status
     builder.builder_status.project = proj
-    builder.builder_status.pendingBuildCache = PendingBuildsCache(builder.builder_status)
+    builder.builder_status.pendingBuildsCache = PendingBuildsCache(builder.builder_status)
     builder.builder_status.nextBuildNumber = 1
     builder.builder_status.basedir = '/basedir'
     builder.builder_status.saveYourself = lambda skipBuilds=True: True
@@ -511,7 +511,7 @@ class TestSinglePendingBuildsJsonResource(unittest.TestCase):
             requests = [1, 2, 3]
             return [getBuildRequestStatus(id) for id in requests]
 
-        builder.builder_status.pendingBuildCache.fetchPendingBuildRequestStatuses = fetchPendingBuildRequestStatuses
+        builder.builder_status.pendingBuildsCache.fetchPendingBuildRequestStatuses = fetchPendingBuildRequestStatuses
 
         pending_json = status_json.SinglePendingBuildsJsonResource(self.master_status, builder.builder_status)
         pending_dict = yield pending_json.asDict(self.request)

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -501,18 +501,19 @@ class TestSinglePendingBuildsJsonResource(unittest.TestCase):
             brstatus.getBuildProperties = lambda: Properties()
             return brstatus
 
-        def getPendingBuildRequestStatuses(codebases={}):
+        def fetchPendingBuildRequestStatuses(codebases={}):
             requests = [1, 2, 3]
             return [getBuildRequestStatus(id) for id in requests]
 
-        builder.builder_status.getPendingBuildRequestStatuses = getPendingBuildRequestStatuses
+        builder.builder_status.fetchPendingBuildRequestStatuses = fetchPendingBuildRequestStatuses
+
         pending_json = status_json.SinglePendingBuildsJsonResource(self.master_status, builder.builder_status)
         pending_dict = yield pending_json.asDict(self.request)
 
         def pendingBuildRequestDict(brid):
             return {'brid': brid, 'builderFriendlyName': 'builder-01', 'builderName': 'builder-01',
-                    'builderURL': 'http://localhost:8080/projects/Katana/builders/builder-01?' +
-                                  'katana-buildbot_branch=katana',
+                    'builderURL': 'http://localhost:8080/projects/Katana/builders/builder-01' +
+                                  '?katana-buildbot_branch=katana',
                     'builds': [],
                     'properties': [],
                     'lastBuildNumber': None,

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -167,7 +167,9 @@ class TestBuildJsonResource(unittest.TestCase):
                                                         'url': u'https://github.com/test/repo/commit/abcdef123456789'}],
                           'results': 0, 'number': 1, 'currentStep': None,
                           'times': (1422441500, 1422441501.21),
-                          'buildChainID': None, 'owners': None, 'submittedTime': None,
+                          'buildChainID': None,
+                          'buildRequestID': None,
+                          'owners': None, 'submittedTime': None,
                           'blame': [],
                           'builder_url': 'http://localhost:8080/projects/Katana/builders/builder-01' +
                                          '?katana-buildbot_branch=katana&_branch=b',
@@ -270,7 +272,9 @@ class TestPastBuildsJsonResource(unittest.TestCase):
                     'number': num, 'properties': [], 'reason': 'A build was forced by user@localhost',
                     'results': 0, 'results_text': 'success', 'slave': 'build-slave-01',
                     'slave_friendly_name': 'build-slave-01', 'slave_url': None,
-                    'sourceStamps': [], 'steps': [], 'buildChainID': None, 'owners': None,
+                    'sourceStamps': [], 'steps': [], 'buildChainID': None,
+                    'buildRequestID': None,
+                    'owners': None,
                      'submittedTime': None,
                     'text': [], 'times': (1422441500, 1422441501.21),
                     'url': {
@@ -393,7 +397,9 @@ class TestSingleProjectJsonResource(unittest.TestCase):
                      'text': [],
                      'sourceStamps': [],
                      'results': 0,
-                     'number': 1, 'artifacts': None, 'blame': [], 'buildChainID': None, 'owners': None,
+                     'number': 1, 'artifacts': None, 'blame': [], 'buildChainID': None,
+                     'buildRequestID': None,
+                     'owners': None,
                      'submittedTime': None,
                      'builder_url': 'http://localhost:8080/projects/Katana/builders/builder-01' +
                                     '?katana-buildbot_branch=katana',

--- a/master/buildbot/test/unit/test_step_locks.py
+++ b/master/buildbot/test/unit/test_step_locks.py
@@ -11,6 +11,7 @@ from buildbot.test.fake.fakemaster import FakeMaster
 
 class FakeRequest:
     def __init__(self):
+        self.id = None
         self.sources = []
         self.reason = "Because"
         self.properties = Properties()


### PR DESCRIPTION
- Adding buildRequestID to build status, to be able to track the build since it was requested
- BuilderStatus PendingBuildsCache support codebases, it has a cache of BuildRequestStatus objects (50 by default, configurable in master.cfg c['caches'] = {'BuilderBuildRequestStatus': 10})
- New request argument pending_builds for  Project json, when users requests /json/project/[project-name]?pending_builds=1, it will return details of the pending builds
