### PR TITLE
Clean up twistd.pid after a force kill

### DIFF
--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -21,7 +21,6 @@ from twisted.python.runtime import platformType
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import ReconfigError
-import psutil
 
 class Follower:
     def follow(self, basedir):
@@ -106,30 +105,11 @@ def launch(config):
     # ProcessProtocol just ignores all output
     reactor.spawnProcess(protocol.ProcessProtocol(), sys.executable, argv, env=os.environ)
 
-def checkPIDFile(basedir):
-    pidfile = os.path.join(basedir, 'twistd.pid')
-    if os.path.isfile(pidfile):
-        try:
-            with open(pidfile, "r") as f:
-                pid = int(f.read().strip())
-                if psutil.pid_exists(pid):
-                    print "Warning: buildbot is already running"
-                    return False
-                else:
-                    print "Removing twistd.pid, pid {} is not running".format(pid)
-                    os.unlink(pidfile)
-
-        except Exception as ex:
-            print "An exception has occurred while checking twistd.pid"
-            print ex
-            return False
-    return True
-
 def start(config):
     if not base.isBuildmasterDir(config['basedir']):
         return 1
 
-    if not checkPIDFile(config['basedir']):
+    if base.isBuildBotRunning(config['basedir'], config['quiet']):
         return 1
 
     if config['nodaemon']:

--- a/master/buildbot/scripts/start.py
+++ b/master/buildbot/scripts/start.py
@@ -21,6 +21,7 @@ from twisted.python.runtime import platformType
 from buildbot.scripts.logwatcher import LogWatcher
 from buildbot.scripts.logwatcher import BuildmasterTimeoutError
 from buildbot.scripts.logwatcher import ReconfigError
+import psutil
 
 class Follower:
     def follow(self, basedir):
@@ -105,8 +106,30 @@ def launch(config):
     # ProcessProtocol just ignores all output
     reactor.spawnProcess(protocol.ProcessProtocol(), sys.executable, argv, env=os.environ)
 
+def checkPIDFile(basedir):
+    pidfile = os.path.join(basedir, 'twistd.pid')
+    if os.path.isfile(pidfile):
+        try:
+            with open(pidfile, "r") as f:
+                pid = int(f.read().strip())
+                if psutil.pid_exists(pid):
+                    print "Warning: buildbot is already running"
+                    return False
+                else:
+                    print "Removing twistd.pid, pid {} is not running".format(pid)
+                    os.unlink(pidfile)
+
+        except Exception as ex:
+            print "An exception has occurred while checking twistd.pid"
+            print ex
+            return False
+    return True
+
 def start(config):
     if not base.isBuildmasterDir(config['basedir']):
+        return 1
+
+    if not checkPIDFile(config['basedir']):
         return 1
 
     if config['nodaemon']:

--- a/master/buildbot/scripts/stop.py
+++ b/master/buildbot/scripts/stop.py
@@ -42,7 +42,8 @@ def stop(config, signame="TERM", wait=False):
 
     signum = getattr(signal, "SIG"+signame)
     try:
-        os.kill(pid, signum)
+        if base.isBuildBotRunning(basedir, quiet):
+            os.kill(pid, signum)
     except OSError, e:
         if e.errno != errno.ESRCH:
             raise

--- a/master/setup.py
+++ b/master/setup.py
@@ -199,7 +199,8 @@ else:
         'pymysql == 0.7.1',
         'PyJWT == 1.4.0',
         'pynats == 0.0.1',
-        'www'
+        'www',
+        'psutil == 4.3.0',
     ]
     setup_args['tests_require'] = [
         'mock == 1.3.0',

--- a/slave/buildslave/scripts/start.py
+++ b/slave/buildslave/scripts/start.py
@@ -16,7 +16,6 @@
 
 import os, sys, time
 from buildslave.scripts import base
-import psutil
 
 class Follower:
     def follow(self):
@@ -78,31 +77,12 @@ stop it, fix the config file, and restart.
         self.rc = 1
         reactor.stop()
 
-def checkPIDFile(basedir):
-    pidfile = os.path.join(basedir, 'twistd.pid')
-    if os.path.isfile(pidfile):
-        try:
-            with open(pidfile, "r") as f:
-                pid = int(f.read().strip())
-                if psutil.pid_exists(pid):
-                    print "Warning: buildslave is already running"
-                    return False
-                else:
-                    print "Removing twistd.pid, pid {} is not running".format(pid)
-                    os.unlink(pidfile)
-
-        except Exception as ex:
-            print "An exception has occurred while checking twistd.pid"
-            print ex
-            return False
-    return True
-
 def startCommand(config):
     basedir = config['basedir']
     if not base.isBuildslaveDir(basedir):
         return 1
 
-    if not checkPIDFile(basedir):
+    if base.isBuildSlaveRunning(basedir, config['quiet']):
         return 1
 
     return startSlave(basedir, config['quiet'], config['nodaemon'])

--- a/slave/buildslave/scripts/stop.py
+++ b/slave/buildslave/scripts/stop.py
@@ -49,7 +49,8 @@ def stopSlave(basedir, quiet, signame="TERM"):
     signum = getattr(signal, "SIG" + signame)
     timer = 0
     try:
-        os.kill(pid, signum)
+        if base.isBuildSlaveRunning(basedir, quiet):
+            os.kill(pid, signum)
     except OSError, e:
         if e.errno != 3:
             raise

--- a/slave/buildslave/test/unit/test_scripts_stop.py
+++ b/slave/buildslave/test/unit/test_scripts_stop.py
@@ -21,6 +21,7 @@ import signal
 from twisted.trial import unittest
 from buildslave.scripts import stop
 from buildslave.test.util import misc
+from buildslave.scripts import base
 
 
 class TestStopSlave(misc.FileIOMixin,
@@ -36,6 +37,7 @@ class TestStopSlave(misc.FileIOMixin,
 
         # patch os.chdir() to do nothing
         self.patch(os, "chdir", mock.Mock())
+        base.isBuildSlaveRunning = lambda basedir, quiet: True
 
     def test_no_pid_file(self):
         """

--- a/slave/setup.py
+++ b/slave/setup.py
@@ -120,6 +120,7 @@ except ImportError:
 else:
     setup_args['install_requires'] = [
         'twisted >= 8.0.0',
+        'psutil == 4.3.0',
     ]
     setup_args['tests_require'] = [
         'mock',


### PR DESCRIPTION
When the slave or master is force kill, the file twistd.pid is still around preventing the software to start
