### PR TITLE
Add new links in Katana UI

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -123,7 +123,7 @@ class MasterConfig(object):
         "multiMaster", "prioritizeBuilders", "projects", "projectName", "projectURL",
         "properties", "revlink", "schedulers", "slavePortnum", "slaves",
         "status", "title", "titleURL", "user_managers", "validation", "realTimeServer", "analytics_code", "gzip",
-        "autobahn_push", "lastBuildCacheDays", "requireLogin", "globalFactory"
+        "autobahn_push", "lastBuildCacheDays", "requireLogin", "globalFactory", "slave_debug_url"
     ])
 
     @classmethod
@@ -259,6 +259,7 @@ class MasterConfig(object):
         copy_str_param('titleURL', alt_key='projectURL')
 
         copy_str_param('buildbotURL')
+        copy_str_param('slave_debug_url')
 
         # Make sure that buildbotURL ends with a forward slash
         if not self.buildbotURL.endswith('/'):

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -287,6 +287,7 @@ class StatusResourceBuild(HtmlResource):
         cxt['path_to_builders'] = path_to_builders(req, project)
         cxt['path_to_codebases'] = path_to_codebases(req, project)
         cxt['build_url'] = path_to_build(req, b, False)
+        cxt['slave_debug_url'] = self.getBuildmaster(req).config.slave_debug_url
         codebases_arg = cxt['codebases_arg'] = getCodebasesArg(request=req)
 
         if not b.isFinished():

--- a/www/templates/build.html
+++ b/www/templates/build.html
@@ -365,7 +365,7 @@
             </div>
             {% if result_css == "failure" %}
             <div>
-                <a class="small-head" target="_blank" href="https://q.unity3d.com/questions/244/how-do-i-connect-to-a-build-machine.html">
+                <a class="small-head" target="_blank" href={{ slave_debug_url }}>
                     Build Failure? Only Happens on Katana?
                 </a>
             </div>

--- a/www/templates/build.html
+++ b/www/templates/build.html
@@ -361,7 +361,12 @@
             </div>
             <div class="divider"></div>
             <div>
-                <a class="small-head" href={{ build_url+"?debug=true" }}>Show hidden steps</a>
+                <a class="small-head"
+                {% if request.args %}
+                href={{ request.uri+"&debug=true" }}
+                {% else %}
+                href={{ request.uri+"?debug=true" }}
+                {% endif %}>Show hidden steps</a>
             </div>
             {% if result_css == "failure" %}
             <div>

--- a/www/templates/build.html
+++ b/www/templates/build.html
@@ -361,12 +361,8 @@
             </div>
             <div class="divider"></div>
             <div>
-                <a class="small-head"
-                {% if request.args %}
-                href={{ request.uri+"&debug=true" }}
-                {% else %}
-                href={{ request.uri+"?debug=true" }}
-                {% endif %}>Show hidden steps</a>
+                {% set query_symbol = "&" if request.args else "?" %}
+                <a class="small-head" href={{ request.uri+query_symbol+"debug=true" }}>Show hidden steps</a>
             </div>
             {% if result_css == "failure" %}
             <div>

--- a/www/templates/build.html
+++ b/www/templates/build.html
@@ -359,6 +359,17 @@
             <div id="artifacts-js">
                 No artifacts
             </div>
+            <div class="divider"></div>
+            <div>
+                <a class="small-head" href={{ build_url+"?debug=true" }}>Show hidden steps</a>
+            </div>
+            {% if result_css == "failure" %}
+            <div>
+                <a class="small-head" target="_blank" href="https://q.unity3d.com/questions/244/how-do-i-connect-to-a-build-machine.html">
+                    Build Failure? Only Happens on Katana?
+                </a>
+            </div>
+            {% endif %}
             <div class="more-info-box more-info-box-js">
                 <a class="close-btn" href="#"> </a>
 
@@ -380,16 +391,6 @@
 
             </ol>
 
-            <div>
-                <a class="small-head" href={{ build_url+"?debug=true" }}>Show hidden steps</a>
-            </div>
-            {% if result_css == "failure" %}
-            <div>
-                <a class="small-head" target="_blank" href="https://q.unity3d.com/questions/244/how-do-i-connect-to-a-build-machine.html">
-                    Build Failure? Only Happens on Katana?
-                </a>
-            </div>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/www/templates/build.html
+++ b/www/templates/build.html
@@ -359,8 +359,6 @@
             <div id="artifacts-js">
                 No artifacts
             </div>
-
-
             <div class="more-info-box more-info-box-js">
                 <a class="close-btn" href="#"> </a>
 
@@ -381,6 +379,17 @@
             <ol id="stepList" class="step-list">
 
             </ol>
+
+            <div>
+                <a class="small-head" href={{ build_url+"?debug=true" }}>Show hidden steps</a>
+            </div>
+            {% if result_css == "failure" %}
+            <div>
+                <a class="small-head" target="_blank" href="https://q.unity3d.com/questions/244/how-do-i-connect-to-a-build-machine.html">
+                    Build Failure? Only Happens on Katana?
+                </a>
+            </div>
+            {% endif %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Added links to the buildpage to show all the buildsteps, and a link on how to connect to a buildagent when a build fails.
