### PR TITLE
Adding support for setting builderstatus.project

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -99,7 +99,8 @@ class Builder(config.ReconfigurableServiceMixin,
                     builder_config.name,
                     builder_config.builddir,
                     builder_config.category, builder_config.friendly_name,
-                    builder_config.description)
+                    builder_config.description,
+                    project=builder_config.project)
 
         self.config = builder_config
 

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -101,12 +101,12 @@ class BuilderStatus(styles.Versioned):
     unavailable_build_numbers = set()
     status = None
 
-    def __init__(self, buildername, category, master, friendly_name=None, description=None):
+    def __init__(self, buildername, category, master, friendly_name=None, description=None, project=None):
         self.name = buildername
         self.category = category
         self.description = description
         self.master = master
-        self.project = None
+        self.project = project
         self.friendly_name = friendly_name
 
         self.slavenames = []

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -448,7 +448,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
         if t:
             builder_status.subscribe(t)
 
-    def builderAdded(self, name, basedir, category=None, friendly_name=None, description=None):
+    def builderAdded(self, name, basedir, category=None, friendly_name=None, description=None, project=None):
         """
         @rtype: L{BuilderStatus}
         """
@@ -484,7 +484,7 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
             log.err()
         if not builder_status:
             builder_status = builder.BuilderStatus(name, category, self.master, friendly_name,
-                                                   description)
+                                                   description, project=project)
             builder_status.addPointEvent(["builder", "created"])
         log.msg("added builder %s in category %s" % (name, category))
         # an unpickled object might not have category set from before,

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -56,7 +56,7 @@ class FakeStatus(object):
         pass
 
 
-    def builderAdded(self, name, basedir, category=None, friendly_name=None, description=None):
+    def builderAdded(self, name, basedir, category=None, friendly_name=None, description=None, project=None):
         return FakeBuilderStatus(self.master)
 
     def build_started(self, brid, buildername, build_status):


### PR DESCRIPTION
This is to fix the reconfig error:

File "/home/buildbot/katana/master/buildbot/status/master.py", line 215, in getURLForThing
urllib.quote(bldr.getProject(), safe=''),
File "/usr/lib/pypy/lib-python/2.7/urllib.py", line 1291, in quote
raise TypeError('None object cannot be quoted')
exceptions.TypeError: None object cannot be quoted

It looks like a required variable was left out when the builder status is created.
