### PR TITLE
Data clean up job and configure data lifetime

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -67,6 +67,8 @@ class MasterConfig(object):
         self.titleURL = 'http://buildbot.net'
         self.buildbotURL = 'http://localhost:8080/'
         self.changeHorizon = None
+        self.cleanUpPeriod = None
+        self.buildRequestsDays = None
         self.eventHorizon = 50
         self.logHorizon = None
         self.buildHorizon = None
@@ -123,8 +125,10 @@ class MasterConfig(object):
         "logMaxSize", "logMaxTailSize", "manhole", "mergeRequests", "metrics",
         "multiMaster", "prioritizeBuilders", "projects", "projectName", "projectURL",
         "properties", "revlink", "schedulers", "slavePortnum", "slaves",
-        "status", "title", "titleURL", "user_managers", "validation", "realTimeServer", "analytics_code", "gzip",
-        "autobahn_push", "lastBuildCacheDays", "requireLogin", "globalFactory", "slave_debug_url"
+        "status", "title", "titleURL", "user_managers", "validation", "realTimeServer",
+        "analytics_code", "gzip", "autobahn_push", "lastBuildCacheDays",
+        "requireLogin", "globalFactory", "slave_debug_url",
+        "cleanUpPeriod", "buildRequestsDays"
     ])
 
     @classmethod
@@ -268,7 +272,9 @@ class MasterConfig(object):
         copy_str_param('realTimeServer')
         copy_str_param('analytics_code')
 
+        copy_int_param('cleanUpPeriod')
         copy_int_param('changeHorizon')
+        copy_int_param('buildRequestsDays')
         copy_int_param('eventHorizon')
         copy_int_param('logHorizon')
         copy_int_param('buildHorizon')

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -18,7 +18,7 @@ import sqlalchemy as sa
 from sqlalchemy import or_
 from sqlalchemy import func
 from datetime import datetime, timedelta
-from twisted.internet import reactor
+from twisted.internet import reactor, defer
 from twisted.python import log
 from buildbot.db import base
 from buildbot.util import json
@@ -1137,6 +1137,71 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
 
         d.addCallback(log_nonzero_count)
         return d
+
+    def pruneBuildRequests(self, buildRequestsDays):
+        if not buildRequestsDays:
+            return defer.succeed(None)
+
+        def thd(conn):
+            if self.db.pool.engine.dialect.name != 'mysql':
+                # sqlite doesnt have integrity constraints, we should check if this approach works on postgre
+                log.msg("pruneBuildRequests is not yet supported for %s" % self.db.pool.engine.dialect.name)
+                return
+
+            try:
+                buildrequests_tbl = self.db.model.buildrequests
+                buildsets_tbl = self.db.model.buildsets
+                sourcestampsets_tbl = self.db.model.sourcestampsets
+
+                prune_period = datetime.now().date() - timedelta(buildRequestsDays)
+                prune_period_epoch = datetime2epoch(datetime(prune_period.year, prune_period.month, prune_period.day))
+
+                transaction = conn.begin()
+                stmt_brids = sa.select([buildrequests_tbl.c.id])\
+                    .where(buildrequests_tbl.c.submitted_at <= prune_period_epoch).limit(100)
+
+                res = conn.execute(stmt_brids)
+                brids = [r.id for r in res]
+
+                if not brids:
+                    return
+
+                log.msg("Prune %d buildrequests" % len(brids))
+
+                stmt_bsids = sa.select(
+                        [buildsets_tbl.c.id],
+                        from_obj=buildsets_tbl.join(
+                                buildrequests_tbl, buildsets_tbl.c.id == buildrequests_tbl.c.buildsetid))\
+                    .where(buildrequests_tbl.c.id.in_(brids))\
+                    .group_by(buildsets_tbl.c.id)
+
+                res = conn.execute(stmt_bsids)
+                bsids = [r.id for r in res]
+
+                stmt_ssids = sa.select(
+                        [sourcestampsets_tbl.c.id],
+                        from_obj=sourcestampsets_tbl.join(
+                                buildsets_tbl,
+                                buildsets_tbl.c.sourcestampsetid == sourcestampsets_tbl.c.id))\
+                    .where(buildrequests_tbl.c.id.in_(bsids))\
+                    .group_by(sourcestampsets_tbl.c.id)
+
+                res = conn.execute(stmt_ssids)
+                ssids = [r.id for r in res]
+
+                # Cascade delete to related tables
+                conn.execute(sourcestampsets_tbl.delete((sourcestampsets_tbl.c.id.in_(ssids))))
+                conn.execute(buildsets_tbl.delete((buildsets_tbl.c.id.in_(bsids))))
+                conn.execute(buildrequests_tbl.delete((buildrequests_tbl.c.id.in_(brids))))
+
+            except Exception:
+                transaction.rollback()
+                log.msg(Failure(), "Could not pruneBuildRequests")
+                return
+
+            transaction.commit()
+
+        return self.db.pool.do(thd)
 
     def _brdictFromRow(self, row, master_objectid):
         claimed = mine = False

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -47,7 +47,7 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
         yield self.tearDownRealDatabase()
 
     @defer.inlineCallbacks
-    def startService(self, check_version=False):
+    def startService(self, check_version=False, cleanUp=False):
         self.master.config.db['db_url'] = self.db_url
         yield self.db.setup(check_version=check_version)
         self.db.startService()
@@ -57,10 +57,17 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
     # tests
 
     def test_doCleanup_service(self):
+        self.master.config.cleanUpPeriod = 3600
         d = self.startService()
         @d.addCallback
         def check(_):
             self.assertTrue(self.db.cleanup_timer.running)
+
+    def test_doCleanup_unconfigured_cleanUpPeriod(self):
+        d = self.startService()
+        @d.addCallback
+        def check(_):
+            self.assertTrue(self.db.cleanup_timer is None)
 
     def test_doCleanup_unconfigured(self):
         self.db.changes.pruneChanges = mock.Mock(

--- a/master/buildbot/test/unit/test_db_connector.py
+++ b/master/buildbot/test/unit/test_db_connector.py
@@ -72,17 +72,20 @@ class DBConnector(db.RealDatabaseMixin, unittest.TestCase):
     def test_doCleanup_unconfigured(self):
         self.db.changes.pruneChanges = mock.Mock(
                         return_value=defer.succeed(None))
-        self.db._doCleanup()
+        self.db._doCleanup(pruneBuildRequests=False)
         self.assertFalse(self.db.changes.pruneChanges.called)
 
     def test_doCleanup_configured(self):
         self.db.changes.pruneChanges = mock.Mock(
                         return_value=defer.succeed(None))
+        self.db.buildrequests.pruneBuildRequests = mock.Mock(
+                        return_value=defer.succeed(None))
         d = self.startService()
         @d.addCallback
         def check(_):
-            self.db._doCleanup()
+            self.db._doCleanup(pruneBuildRequests=True)
             self.assertTrue(self.db.changes.pruneChanges.called)
+            self.assertTrue(self.db.buildrequests.pruneBuildRequests.called)
         return d
 
     def test_setup_check_version_bad(self):


### PR DESCRIPTION
Add new master.cfg configuration parameters: 
- cleanUpPeriod: How often the db clean up job runs in seconds
- buildRequestsDays: The number of number of days that we keep the buildrequests, older requests will be deleted
