### PR TITLE
Skip KatanaBuildRequestDistributor task if master dont have builders configured

### DIFF
--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -1119,7 +1119,7 @@ class KatanaBuildRequestDistributor(service.Service):
         @param new_builders: names of new builders that should be given the
         opportunity to check for new requests.
         """
-        if not self.running:
+        if not self.running or not self.master.config.builders:
             return
 
         d = self._maybeStartOrResumeBuildsOn(new_builders)
@@ -1145,8 +1145,6 @@ class KatanaBuildRequestDistributor(service.Service):
         self.check_new_builds = True
         self.check_resume_builds = True
         self.katanaBuildChooser.initializeBuildRequestQueue()
-
-
 
     @defer.inlineCallbacks
     def _selectNextBuildRequest(self, queue, asyncFunc):

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -292,6 +292,15 @@ class TestKatanaBuildRequestDistributorMaybeStartBuildsOn(KatanaBuildRequestDist
         yield self.tearDownComponents()
         yield self.stopKatanaBuildRequestDistributor()
 
+    @defer.inlineCallbacks
+    def test_maybeStartBuildsOnShouldBeSkipped(self):
+        self.brd.master.config.builders = []
+        yield self.generateResumeBuilds()
+        yield self.brd.maybeStartBuildsOn(['bldr1', 'bldr2'])
+
+        self.checkBRDCleanedUp()
+        self.assertEquals(self.processedBuilds, [])
+
     def test_maybeStartBuildsOnCheckNewBuilds(self):
 
         self.setupBuilderInMaster(name='bldr1', slavenames={'slave-01': False, 'slave-02': True},


### PR DESCRIPTION
KatanaBuildRequestDistributor should skipped trying to process builds if the master don't have any builders configured
