### PR TITLE
Made pollers check for existing users by email.

### DIFF
--- a/master/buildbot/db/users.py
+++ b/master/buildbot/db/users.py
@@ -179,6 +179,20 @@ class UsersConnectorComponent(base.DBConnectorComponent):
         d = self.db.pool.do(thd)
         return d
 
+    def getIdentifierByMail(self, mail, author):
+        def thd(conn):
+            tbl = self.db.model.users
+
+            q = tbl.select(whereclause=(tbl.c.mail == mail))
+            users_row = conn.execute(q).fetchone()
+
+            if not users_row:
+                return author
+
+            return users_row.identifier
+        d = self.db.pool.do(thd)
+        return d
+
     def getUsers(self):
         def thd(conn):
             tbl = self.db.model.users

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -495,7 +495,6 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         d = defer.succeed(None)
         if src:
-            print mail
             # create user object, returning a corresponding uid
             d.addCallback(lambda _: users.createUserObject(self, author, src, mail))
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -381,7 +381,7 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
     ## triggering methods and subscriptions
 
     def addChange(self, who=None, files=None, comments=None, author=None,
-            isdir=None, is_dir=None, revision=None, when=None,
+            mail=None, isdir=None, is_dir=None, revision=None, when=None,
             when_timestamp=None, branch=None, category=None, revlink='',
             properties={}, repository='', codebase=None, project='', src=None):
         """
@@ -492,28 +492,29 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
                 codebase = self.config.codebaseGenerator(chdict)
             else:
                 codebase = ''
-            
+
         d = defer.succeed(None)
         if src:
+            print mail
             # create user object, returning a corresponding uid
-            d.addCallback(lambda _ : users.createUserObject(self, author, src))
-         
+            d.addCallback(lambda _: users.createUserObject(self, author, src, mail))
+
         # add the Change to the database
-        d.addCallback(lambda uid :
-                          self.db.changes.addChange(author=author, files=files,
-                                          comments=comments, is_dir=is_dir,
-                                          revision=revision,
-                                          when_timestamp=when_timestamp,
-                                          branch=branch, category=category,
-                                          revlink=revlink, properties=properties,
-                                          repository=repository, codebase=codebase,
-                                          project=project, uid=uid))
+        d.addCallback(lambda uid:
+                      self.db.changes.addChange(author=author, files=files,
+                                                comments=comments, is_dir=is_dir,
+                                                revision=revision,
+                                                when_timestamp=when_timestamp,
+                                                branch=branch, category=category,
+                                                revlink=revlink, properties=properties,
+                                                repository=repository, codebase=codebase,
+                                                project=project, uid=uid))
 
         # convert the changeid to a Change instance
-        d.addCallback(lambda changeid :
-            self.db.changes.getChange(changeid))
-        d.addCallback(lambda chdict :
-            changes.Change.fromChdict(self, chdict))
+        d.addCallback(lambda changeid:
+                      self.db.changes.getChange(changeid))
+        d.addCallback(lambda chdict:
+                      changes.Change.fromChdict(self, chdict))
 
         def notify(change):
             msg = u"added change %s to database" % change

--- a/master/buildbot/process/users/users.py
+++ b/master/buildbot/process/users/users.py
@@ -29,7 +29,7 @@ except ImportError:
 srcs = ['git', 'svn', 'hg', 'cvs', 'darcs', 'bzr']
 salt_len = 8
 
-def createUserObject(master, author, src=None):
+def createUserObject(master, author, src=None, mail=None):
     """
     Take a Change author and source and translate them into a User Object,
     storing the user in master.db, or returning None if the src is not
@@ -55,10 +55,18 @@ def createUserObject(master, author, src=None):
         log.msg("Unrecognized source argument: %s" % src)
         return defer.succeed(None)
 
-    return master.db.users.findUserByAttr(
-            identifier=usdict['identifier'],
+    if mail:
+        d = master.db.users.getIdentifierByMail(mail, author)
+        d.addCallback(lambda ident: master.db.users.findUserByAttr(
+            identifier=ident,
             attr_type=usdict['attr_type'],
-            attr_data=usdict['attr_data'])
+            attr_data=usdict['attr_data']))
+        return d
+
+    return master.db.users.findUserByAttr(
+        identifier=usdict['identifier'],
+        attr_type=usdict['attr_type'],
+        attr_data=usdict['attr_data'])
 
 
 def _extractContact(usdict, contact_types, uid):

--- a/master/buildbot/test/unit/test_changes_custom_poller.py
+++ b/master/buildbot/test/unit/test_changes_custom_poller.py
@@ -32,7 +32,7 @@ class TestCustomPoller(unittest.TestCase):
         poller.master = Mock()
         self.changes_added = []
 
-        def addChange(files=None, comments=None, author=None, revision=None,
+        def addChange(files=None, comments=None, author=None, revision=None, mail=None,
                       when_timestamp=None, branch=None, repository='', codebase=None,
                       category='', project='', src=None):
             self.changes_added.append(Change(revision=revision, files=files,
@@ -95,9 +95,9 @@ class TestCustomPoller(unittest.TestCase):
                                        'stdout': defer.succeed('194446:70fc4de2ff3828a587d80f7528c1b5314c51550e7')})
 
         self.expected_commands.append({'command': ['log', '-r', '70fc4de2ff3828a587d80f7528c1b5314c51550e7',
-                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}'],
+                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}\\n{author|email}'],
                                        'stdout':
-                                           defer.succeed('1422983233 -3600\ndev4 <dev4@mail.com>\nlist of changes4')})
+                                           defer.succeed('1422983233 -3600\ndev4 <dev4@mail.com>\nlist of changes4\ndev4@mail.com')})
 
         self.expected_commands.append({'command':  ['log', '-b', '1.0/dev', '-r',
                                                     '2:117b9a27b5bf65d7e7b5edb48f7fd59dc4170486',
@@ -107,19 +107,19 @@ class TestCustomPoller(unittest.TestCase):
                                                                '4:117b9a27b5bf65d7e7b5edb48f7fd59dc4170486\n')})
 
         self.expected_commands.append({'command': ['log', '-r', '5553a6194a6393dfbec82f96654d52a76ddf844d',
-                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}'],
+                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}\\n{author|email}'],
                                        'stdout':
-                                           defer.succeed('1421583649 -3600\ndev3 <dev3@mail.com>\nlist of changes3')})
+                                           defer.succeed('1421583649 -3600\ndev3 <dev3@mail.com>\nlist of changes3\ndev3@mail.com')})
 
         self.expected_commands.append({'command': ['log', '-r', 'b2e48cbab3f0753f99db833acff6ca18096854bd',
-                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}'],
+                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}\\n{author|email}'],
                                        'stdout':
-                                           defer.succeed('1421667112 -3600\ndev2 <dev2@mail.com>\nlist of changes2')})
+                                           defer.succeed('1421667112 -3600\ndev2 <dev2@mail.com>\nlist of changes2\ndev2@mail.com')})
 
         self.expected_commands.append({'command': ['log', '-r', '117b9a27b5bf65d7e7b5edb48f7fd59dc4170486',
-                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}'],
+                                                   '--template={date|hgdate}\\n{author}\\n{desc|strip}\\n{author|email}'],
                                        'stdout':
-                                           defer.succeed('1421667230 -3600\ndev1 <dev1@mail.com>\nlist of changes1')})
+                                           defer.succeed('1421667230 -3600\ndev1 <dev1@mail.com>\nlist of changes1\ndev1@mail.com')})
 
         yield poller._processChangesAllBranches(None)
 
@@ -163,18 +163,22 @@ class TestCustomPoller(unittest.TestCase):
                                                    '-1', '--'],
                                        'stdout': defer.succeed('70fc4de2ff3828a587d80f7528c1b5314c51550e7')})
 
-        def getExpectedCmd(revision, when, developer, comments):
+        def getExpectedCmd(revision, when, developer, comments, mail):
             return [{'command': ['log', '--no-walk', '--format=%ct', revision, '--'],
                      'stdout': defer.succeed(when)},
                     {'command': ['log', '--no-walk', '--format=%aN <%aE>', revision, '--'],
                      'stdout': defer.succeed(developer)},
                     {'command': ['log', '--no-walk', '--format=%s%n%b', revision, '--'],
-                     'stdout': defer.succeed(comments)}]
+                     'stdout': defer.succeed(comments)},
+                    {'command': ['log', '--no-walk', '--format=%aE', revision, '--'],
+                     'stdout': defer.succeed(mail)},
+                    ]
 
         self.expected_commands += getExpectedCmd('70fc4de2ff3828a587d80f7528c1b5314c51550e7',
                                                  1422983233,
                                                  'dev4 <dev4@mail.com>',
-                                                 'list of changes4')
+                                                 'list of changes4',
+                                                 'dev4@mail.com')
 
         self.expected_commands\
             .append(
@@ -188,17 +192,20 @@ class TestCustomPoller(unittest.TestCase):
         self.expected_commands += getExpectedCmd('117b9a27b5bf65d7e7b5edb48f7fd59dc4170486',
                                                  1421667230,
                                                  'dev1 <dev1@mail.com>',
-                                                 'list of changes1')
+                                                 'list of changes1',
+                                                 'dev1@mail.com')
 
         self.expected_commands += getExpectedCmd('b2e48cbab3f0753f99db833acff6ca18096854bd',
                                                  1421667112,
                                                  'dev2 <dev2@mail.com>',
-                                                 'list of changes2')
+                                                 'list of changes2',
+                                                 'dev2@mail.com')
 
         self.expected_commands += getExpectedCmd('5553a6194a6393dfbec82f96654d52a76ddf844d',
                                                  1421583649,
                                                  'dev3 <dev3@mail.com>',
-                                                 'list of changes3')
+                                                 'list of changes3',
+                                                 'dev3@mail.com')
 
         yield poller._processChangesAllBranches(None)
 

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -177,8 +177,8 @@ class Subscriptions(dirs.DirsMixin, unittest.TestCase):
     def test_addChange_createUserObject_args(self):
         # who should come through as author
         return self.do_test_createUserObjects_args(
-                kwargs=dict(who='me', src='git'),
-                exp_args=(self.master, 'me', 'git'))
+                kwargs=dict(who='me', src='git', mail='john@doe.com'),
+                exp_args=(self.master, 'me', 'git', 'john@doe.com'))
                
     def test_buildset_subscription(self):
         self.master.db = mock.Mock()


### PR DESCRIPTION
This adds an extra step when new changes are added. The email is
passed around, and used to lookup users in the database such that
new users are not created when a user with the commit email already
exists.
