### PR TITLE
Windows twistd.pid creation and removal fix

### DIFF
--- a/slave/buildslave/scripts/base.py
+++ b/slave/buildslave/scripts/base.py
@@ -53,6 +53,7 @@ def isBuildSlaveRunning(basedir, quiet):
                 printMessage(
                         message="Removing twistd.pid, file has pid {} but buildslave is not running".format(pid),
                         quiet=quiet)
+                f.close()
                 os.unlink(pidfile)
 
         except Exception as ex:

--- a/slave/buildslave/scripts/base.py
+++ b/slave/buildslave/scripts/base.py
@@ -45,16 +45,16 @@ def isBuildSlaveRunning(basedir, quiet):
         try:
             with open(pidfile, "r") as f:
                 pid = int(f.read().strip())
-                if psutil.pid_exists(pid) and any('buildslave' in argument.lower()
-                                                  for argument in psutil.Process(pid).cmdline()):
-                    printMessage(message="buildslave is running", quiet=quiet)
-                    return True
 
-                printMessage(
-                        message="Removing twistd.pid, file has pid {} but buildslave is not running".format(pid),
-                        quiet=quiet)
-                f.close()
-                os.unlink(pidfile)
+            if psutil.pid_exists(pid) and any('buildslave' in argument.lower()
+                                              for argument in psutil.Process(pid).cmdline()):
+                printMessage(message="buildslave is running", quiet=quiet)
+                return True
+
+            printMessage(
+                    message="Removing twistd.pid, file has pid {} but buildslave is not running".format(pid),
+                    quiet=quiet)
+            os.unlink(pidfile)
 
         except Exception as ex:
             print "An exception has occurred while checking twistd.pid"

--- a/slave/buildslave/scripts/start.py
+++ b/slave/buildslave/scripts/start.py
@@ -111,8 +111,22 @@ def startSlave(basedir, quiet, nodaemon):
 
     # we probably can't do this os.fork under windows
     from twisted.python.runtime import platformType
+
     if platformType == "win32":
-        return launch(nodaemon)
+        pidfile = os.path.join(basedir, 'twistd.pid')
+        # Make sure the twistd.pid file actually exists
+        if not os.path.exists(pidfile):
+            with open(pidfile, "w") as f:
+                f.write("{}".format(os.getpid()))
+
+        launch(nodaemon)
+
+        # When Buildbot is closing (which is now), delete the PID
+
+        if os.path.exists(pidfile):
+            os.remove(pidfile)
+
+        return
 
     # fork a child to launch the daemon, while the parent process tails the
     # logfile

--- a/slave/buildslave/test/unit/test_scripts_stop.py
+++ b/slave/buildslave/test/unit/test_scripts_stop.py
@@ -35,8 +35,7 @@ class TestStopSlave(misc.FileIOMixin,
     def setUp(self):
         self.setUpStdoutAssertions()
 
-        # patch os.chdir() to do nothing
-        self.patch(os, "chdir", mock.Mock())
+        os.path.join = lambda basedir, pidfile: pidfile
         base.isBuildSlaveRunning = lambda basedir, quiet: True
 
     def test_no_pid_file(self):
@@ -63,7 +62,7 @@ class TestStopSlave(misc.FileIOMixin,
                 raise OSError(errno.ESRCH, "dummy")
 
         # patch open() to return a pid file
-        self.setUpOpen(str(self.PID))
+        self.setUpOpenContextManager(str(self.PID))
 
         # patch os.kill to emulate successful kill
         mocked_kill = mock.Mock(side_effect=emulated_kill)

--- a/slave/buildslave/test/util/misc.py
+++ b/slave/buildslave/test/util/misc.py
@@ -21,6 +21,7 @@ import shutil
 import __builtin__
 import cStringIO
 from buildslave.scripts import base
+from mock import mock_open
 
 
 def nl(s):
@@ -93,6 +94,10 @@ class FileIOMixin:
         # patch open() to return mocked object
         self.open = mock.Mock(return_value=self.fileobj)
         self.patch(__builtin__, "open", self.open)
+
+    def setUpOpenContextManager(self, file_contents="dummy-contents"):
+        self.fileobj = mock_open(read_data=file_contents)
+        self.patch(__builtin__, "open", self.fileobj)
 
     def setUpOpenError(self, errno=errno.ENOENT, strerror="dummy-msg",
                        filename="dummy-file"):


### PR DESCRIPTION
twisted is not creating twistd.pid file on windows, the following fixes handles the creation and removal
