### PR TITLE
Added 'Smart Select' checkbox to Katana's 'Run Custom Build' popup

### DIFF
--- a/www/templates/forms.html
+++ b/www/templates/forms.html
@@ -115,6 +115,11 @@
         <span title="Checking this box will force the build to be rebuilt, regardless of whether or not there is a previous successful build at the same revision. If the build triggers dependencies, those will also be rebuilt." class="tooltip question-icon">
       </span>
        <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
+    {% elif 'Smart Select' in f.label%}
+       <span class="label">{{f.label}}</span>
+        <span title="Enables Smart Tests Selection. Read more at: http://tinyurl.com/h32rusw. For now this applicable to 'Test IntegrationTests - Windows64Editor' builder only. For the rest it will be ignored." class="tooltip question-icon">
+      </span>
+       <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
     {% elif 'textarea' in f.type %}
        <span class="label">{{f.label}}</span>
        <textarea name='{{f.fullName}}' rows={{f.rows}} cols={{f.cols}}>{{default_props[sch.name+"."+f.fullName]}}</textarea>


### PR DESCRIPTION
A 'Smart Select' checkbox has been added into Katana's 'Run Custom Build' popup. 

This check box will enable the Smart Tests Selection functionality, which is aimed to reduce the number of tests to run based on statistical information provided by Hoarder.

For now this option can affect only 'Test IntegrationTests - Windows64Editor' configuration. And for the rest will be just ignored.

A screenshot of how it looks like: http://i.imgur.com/QCHp2gV.png
A page where description about Smart Tests Selection will be published: http://tinyurl.com/h32rusw
