### PR TITLE
Added 'Smart Select' checkbox to Katana's 'Run Custom Build' popup

### DIFF
--- a/www/templates/forms.html
+++ b/www/templates/forms.html
@@ -115,6 +115,11 @@
         <span title="Checking this box will force the build to be rebuilt, regardless of whether or not there is a previous successful build at the same revision. If the build triggers dependencies, those will also be rebuilt." class="tooltip question-icon">
       </span>
        <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
+    {% elif 'Smart Select' in f.label%}
+       <span class="label">{{f.label}}</span>
+        <span title="Enables Smart Tests Selection. Read more at: http://tinyurl.com/h32rusw. For now this applicable to 'Test IntegrationTests - Windows64Editor' builder only. For the rest it will be ignored." class="tooltip question-icon">
+      </span>
+       <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
     {% elif 'textarea' in f.type %}
        <span class="label">{{f.label}}</span>
        <textarea name='{{f.fullName}}' rows={{f.rows}} cols={{f.cols}}>{{default_props[sch.name+"."+f.fullName]}}</textarea>

--- a/www/templates/forms.html
+++ b/www/templates/forms.html
@@ -115,11 +115,9 @@
         <span title="Checking this box will force the build to be rebuilt, regardless of whether or not there is a previous successful build at the same revision. If the build triggers dependencies, those will also be rebuilt." class="tooltip question-icon">
       </span>
        <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
-    {% elif 'Smart Select' in f.label%}
-       <span class="label">{{f.label}}</span>
-        <span title="Enables Smart Tests Selection. Read more at: http://tinyurl.com/h32rusw. For now this applicable to 'Test IntegrationTests - Windows64Editor' builder only. For the rest it will be ignored." class="tooltip question-icon">
-      </span>
-       <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
+    {% elif 'bool' in f.type %}
+      <span class="label">{{f.label}}</span>
+      <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
     {% elif 'textarea' in f.type %}
        <span class="label">{{f.label}}</span>
        <textarea name='{{f.fullName}}' rows={{f.rows}} cols={{f.cols}}>{{default_props[sch.name+"."+f.fullName]}}</textarea>


### PR DESCRIPTION
As far as a decision was made to show the 'Smart Select' checkbox only on those builders that support it (https://ono.unity3d.com/katana/buildmaster/pull-request/31575/_/toolsmiths/smart-select) this change on Katana's UI becomes relevant again. 

For now the checkbox will be shown on 'Test IntegrationTests - WindowsEditor' and 'Test JSON Report' builders only.
