### PR TITLE
Fixes services start, stop and reconfigure sequence

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -216,6 +216,7 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
             # give all services a chance to load the new configuration, rather than
             # the base configuration
             yield self.reconfigService(self.config)
+
         except:
             f = failure.Failure()
             log.err(f, 'while starting BuildMaster')
@@ -326,6 +327,8 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         # reconfigure all the services
         yield config.ReconfigurableServiceMixin.reconfigService(self, new_config)
+        # try to start the builds after all the services are configured
+        self.botmaster.maybeStartBuildsForAllBuilders()
 
         # adjust the db poller
         if self.configured_poll_interval != new_config.db['db_poll_interval']:

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -130,11 +130,11 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
         self.change_svc = ChangeManager(self)
         self.change_svc.setServiceParent(self)
 
-        self.scheduler_manager = SchedulerManager(self)
-        self.scheduler_manager.setServiceParent(self)
-
         self.botmaster = BotMaster(self)
         self.botmaster.setServiceParent(self)
+
+        self.scheduler_manager = SchedulerManager(self)
+        self.scheduler_manager.setServiceParent(self)
 
         self.user_manager = UserManagerManager(self)
         self.user_manager.setServiceParent(self)

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -168,11 +168,6 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         yield config.ReconfigurableServiceMixin.reconfigService(self,
                                                     new_config)
 
-        # try to start a build for every builder; this is necessary at master
-        # startup, and a good idea in any other case
-        # it is not a good time to start this here if there are configuration changes in the schedulers
-        # self.maybeStartBuildsForAllBuilders()
-
         timer.stop()
 
 
@@ -331,7 +326,6 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         @param buildername: the name of the builder
         """
-        log.msg("maybeStartBuildsForBuilder")
         self.brd.maybeStartBuildsOn([buildername])
 
     def maybeStartBuildsForSlave(self, slave_name):
@@ -341,7 +335,6 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         @param slave_name: the name of the slave
         """
-        log.msg("maybeStartBuildsForSlave")
         builders = self.getBuildersForSlave(slave_name)
         self.brd.maybeStartBuildsOn([ b.name for b in builders ])
 
@@ -350,7 +343,6 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         Call this when something suggests that this would be a good time to 
         start some builds, but nothing more specific.
         """
-        log.msg("maybeStartBuildsForAllBuilders")
         self.brd.maybeStartBuildsOn(self.builderNames)
 
 

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -170,7 +170,8 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         # try to start a build for every builder; this is necessary at master
         # startup, and a good idea in any other case
-        self.maybeStartBuildsForAllBuilders()
+        # it is not a good time to start this here if there are configuration changes in the schedulers
+        # self.maybeStartBuildsForAllBuilders()
 
         timer.stop()
 

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -159,11 +159,9 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         timer.start()
 
         # reconfigure slaves
-        log.msg("reconfigServiceSlaves")
         yield self.reconfigServiceSlaves(new_config)
 
         # reconfigure builders
-        log.msg("reconfigServiceBuilders")
         yield self.reconfigServiceBuilders(new_config)
 
         # call up

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -159,9 +159,11 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         timer.start()
 
         # reconfigure slaves
+        log.msg("reconfigServiceSlaves")
         yield self.reconfigServiceSlaves(new_config)
 
         # reconfigure builders
+        log.msg("reconfigServiceBuilders")
         yield self.reconfigServiceBuilders(new_config)
 
         # call up
@@ -330,6 +332,7 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         @param buildername: the name of the builder
         """
+        log.msg("maybeStartBuildsForBuilder")
         self.brd.maybeStartBuildsOn([buildername])
 
     def maybeStartBuildsForSlave(self, slave_name):
@@ -339,6 +342,7 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         @param slave_name: the name of the slave
         """
+        log.msg("maybeStartBuildsForSlave")
         builders = self.getBuildersForSlave(slave_name)
         self.brd.maybeStartBuildsOn([ b.name for b in builders ])
 
@@ -347,6 +351,7 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         Call this when something suggests that this would be a good time to 
         start some builds, but nothing more specific.
         """
+        log.msg("maybeStartBuildsForAllBuilders")
         self.brd.maybeStartBuildsOn(self.builderNames)
 
 

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -496,6 +496,10 @@ class KatanaBuildChooser(BasicBuildChooser):
                 log.msg("BuildRequest %d uses unknown builder %s" % (br['brid'], buildername))
                 continue
 
+            if not bldr.config:
+                log.msg("BuildRequest %d uses builder %s with no configuration" % (br['brid'], buildername))
+                continue
+
             if buildername in unavailableBuilderNames and not bldr.building and br['startbrid'] is None:
                 continue
 

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -1130,10 +1130,18 @@ class KatanaBuildRequestDistributor(service.Service):
             return x
         d.addErrback(log.err, "while starting or resuming builds on %s" % (new_builders,))
 
+    # temporary to slow down the service
+    def sleep(self, delay):
+        from twisted.internet import reactor
+        d = defer.Deferred()
+        reactor.callLater(delay, d.callback,1)
+        return d
+
     @defer.inlineCallbacks
     def _maybeStartOrResumeBuildsOn(self, new_builders):
         # start the activity loop, if we aren't already
         #  working on that.
+        # yield self.sleep(5)
         if not self.activity_lock.waiting:
             yield self.activity_lock.acquire()
             self._checkBuildRequests()

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -1134,18 +1134,10 @@ class KatanaBuildRequestDistributor(service.Service):
             return x
         d.addErrback(log.err, "while starting or resuming builds on %s" % (new_builders,))
 
-    # temporary to slow down the service
-    def sleep(self, delay):
-        from twisted.internet import reactor
-        d = defer.Deferred()
-        reactor.callLater(delay, d.callback,1)
-        return d
-
     @defer.inlineCallbacks
     def _maybeStartOrResumeBuildsOn(self, new_builders):
         # start the activity loop, if we aren't already
         #  working on that.
-        # yield self.sleep(5)
         if not self.activity_lock.waiting:
             yield self.activity_lock.acquire()
             self._checkBuildRequests()

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -27,6 +27,7 @@ from buildbot.test.fake import fakedb
 from buildbot.util import epoch2datetime
 from buildbot.changes import changes
 from buildbot.process.users import users
+from twisted.application import service
 
 class Subscriptions(dirs.DirsMixin, unittest.TestCase):
 
@@ -214,6 +215,7 @@ class Subscriptions(dirs.DirsMixin, unittest.TestCase):
 class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase):
 
     def setUp(self):
+        self.calledMethods = []
         self.setUpLogging()
         self.basedir = os.path.abspath('basedir')
         d = self.setUpDirs(self.basedir)
@@ -232,6 +234,8 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
 
             self.master = master.BuildMaster(self.basedir)
             self.master.botmaster = mock.Mock()
+            self.master.db_loop = mock.Mock()
+            self.master.db_loop.stop = lambda: self.methodCalled("db_loop_stop")
             self.db = self.master.db = fakedb.FakeDBConnector(self)
 
         return d
@@ -250,6 +254,8 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
             config.error('oh noes')
         self.patch(config.MasterConfig, 'loadConfig', loadConfig)
 
+    def methodCalled(self, name):
+        self.calledMethods.append(name)
 
     # tests
 
@@ -322,6 +328,19 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
         return d
 
     @defer.inlineCallbacks
+    def test_reconfig_order(self):
+        new_config = self.master.config = config.MasterConfig()
+
+        self.patch(config.ReconfigurableServiceMixin,
+                   "reconfigService",
+                   lambda _, new_config: self.methodCalled("reconfigService"))
+        self.master.botmaster.maybeStartBuildsForAllBuilders = lambda: \
+            self.methodCalled("maybeStartBuildsForAllBuilders")
+
+        yield self.master.reconfigService(new_config)
+        self.assertEquals(self.calledMethods, ['db_loop_stop', 'reconfigService', 'maybeStartBuildsForAllBuilders'])
+
+    @defer.inlineCallbacks
     def test_reconfig_bad_config(self):
         reactor = self.make_reactor()
         self.master.reconfigService = mock.Mock(
@@ -379,6 +398,12 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
 
         db_loop.stop.assert_called_with()
         self.assertEqual(self.master.db_loop, None)
+
+    @defer.inlineCallbacks
+    def test_stopService_order(self):
+        self.master.db_loop.stop = lambda: self.methodCalled("db_loop_stop")
+        yield self.master.stopService()
+        self.assertEquals(self.calledMethods, ['db_loop_stop'])
 
 
 class Polling(dirs.DirsMixin, misc.PatcherMixin, unittest.TestCase):

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -348,9 +348,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
 
         new = config.MasterConfig()
         new.db['db_url'] = 'bbbb'
-
-        self.assertRaises(config.ConfigErrors, lambda :
-                self.master.reconfigService(new))
+        self.failureResultOf(self.master.reconfigService(new), config.ConfigErrors)
 
     def test_reconfigService_start_polling(self):
         loopingcall = mock.Mock()

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -231,6 +231,7 @@ class StartupAndReconfig(dirs.DirsMixin, logging.LoggingMixin, unittest.TestCase
                     classmethod(lambda cls, b, f : cls()))
 
             self.master = master.BuildMaster(self.basedir)
+            self.master.botmaster = mock.Mock()
             self.db = self.master.db = fakedb.FakeDBConnector(self)
 
         return d

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -143,8 +143,6 @@ class TestBotMaster(unittest.TestCase):
                 mock.Mock(side_effect=lambda c : defer.succeed(None)))
         self.patch(self.botmaster, 'reconfigServiceSlaves',
                 mock.Mock(side_effect=lambda c : defer.succeed(None)))
-        self.patch(self.botmaster, 'maybeStartBuildsForAllBuilders',
-                mock.Mock())
 
         old_config, new_config = mock.Mock(), mock.Mock()
         d = self.botmaster.reconfigService(new_config)
@@ -154,8 +152,6 @@ class TestBotMaster(unittest.TestCase):
                     new_config)
             self.botmaster.reconfigServiceSlaves.assert_called_with(
                     new_config)
-            self.assertTrue(
-                    self.botmaster.maybeStartBuildsForAllBuilders.called)
         return d
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Fixes
- We need to stop db_loop before stoping all the services to avoid request re-queue while stopping
- Stop db_loop before reconfiguring the services and run it after the server finished reconfiguring / starting all the services
- Sanity check the bldr has a configuration before trying to process an associated tbuild request
- We need to call maybeStartBuildsForAllBuilders after the master finished configured all the services (removed the called from botmaster)
