### PR TITLE
Added a question icon with a tooltip to the 'Smart Select' checkbox

### DIFF
--- a/www/templates/forms.html
+++ b/www/templates/forms.html
@@ -117,6 +117,7 @@
        <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
     {% elif 'bool' in f.type %}
       <span class="label">{{f.label}}</span>
+      {% if f.tooltip %}<span title='{{f.tooltip}}' class="tooltip question-icon"></span>{% endif %}
       <input type='checkbox' name='checkbox' value='{{f.fullName}}' {{default_props[sch.name+"."+f.fullName]}} />
     {% elif 'textarea' in f.type %}
        <span class="label">{{f.label}}</span>


### PR DESCRIPTION
I've added a question icon with a tooltip to the 'Smart Select' checkbox on Katana's 'Run Custom Build' popup. In order to show the icon the following code must be added to the 'projectconfig.py' file (I'll create a separate PR for that):

BooleanParameter(name="smart_select", label="Smart Select", default=True**, tooltip="Tooltip text"**)

otherwise the icon won't be shown.
