### PR TITLE
Add log download

### DIFF
--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -59,6 +59,7 @@ class TextLog(Resource, ContextMixin):
     implements(IHTMLLog)
 
     asText = False
+    withHeaders = False
     subscribed = False
     iFrame = False
 
@@ -68,8 +69,10 @@ class TextLog(Resource, ContextMixin):
         self.pageTitle = "Log"
 
     def getChild(self, path, req):
-        if path == "text":
+        if path.startswith("text"):
             self.asText = True
+            if path.endswith("with_headers"):
+                self.withHeaders = True
             return self
         if path == "iframe":
             self.iFrame = True
@@ -138,6 +141,8 @@ class TextLog(Resource, ContextMixin):
             project = builder_status.getProject()
             cxt["pageTitle"] = "Log File Contents"
             cxt["iframe_url"] = req.path + "/iframe"
+            cxt["plaintext_url"] = req.path + "/text"
+            cxt["plaintext_with_headers_url"] = req.path + "/text_with_headers"
             cxt["builder_name"] = builder.getFriendlyName()
             cxt['path_to_builder'] = path_to_builder(req, builder_status)
             cxt['path_to_builders'] = path_to_builders(req, project)
@@ -152,7 +157,9 @@ class TextLog(Resource, ContextMixin):
             req.write(data)
 
             return ""
-
+        else:
+            return self.original.getTextWithHeaders() if self.withHeaders else self.original.getText()
+            
 
     def _setContentType(self, req):
         if self.asText:

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -69,8 +69,10 @@ class TextLog(Resource, ContextMixin):
         self.pageTitle = "Log"
 
     def getChild(self, path, req):
-        if path == "text":
+        if path.startswith("text"):
             self.asText = True
+            if path.endswith("with_headers"):
+                self.withHeaders = True
             return self
         if path == "text_with_headers":
             self.asText = True
@@ -126,6 +128,7 @@ class TextLog(Resource, ContextMixin):
         if self.asText:
             return self.original.getTextWithHeaders() if self.withHeaders else self.original.getText()
 
+
         # Else render the logs template
         
         self.template = req.site.buildbot_service.templates.get_template("logs.html")
@@ -165,7 +168,6 @@ class TextLog(Resource, ContextMixin):
 
         return ""
 
-            
 
     def _setContentType(self, req):
         if self.asText:

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -76,10 +76,6 @@ class TextLog(Resource, ContextMixin):
             self.asText = True
             self.withHeaders = True
             return self
-        if path == "text_with_headers":
-            self.asText = True
-            self.withHeaders = True
-            return self
         if path == "iframe":
             self.iFrame = True
             return self
@@ -128,6 +124,10 @@ class TextLog(Resource, ContextMixin):
 
         # If plaintext is requested just return the content of the logfile
         if self.asText:
+            with_headers = "_with_headers" if self.withHeaders else ""
+            base_name = self.original.step.getName() + "_" + self.original.getName() + with_headers
+            base_name = base_name.replace(" ", "_") + ".txt"
+            req.setHeader("Content-Disposition", "inline; filename =\"" + base_name + "\"")
             return self.original.getTextWithHeaders() if self.withHeaders else self.original.getText()
 
 

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -69,10 +69,12 @@ class TextLog(Resource, ContextMixin):
         self.pageTitle = "Log"
 
     def getChild(self, path, req):
-        if path.startswith("text"):
+        if path == "text":
             self.asText = True
-            if path.endswith("with_headers"):
-                self.withHeaders = True
+            return self
+        if path == "text_with_headers":
+            self.asText = True
+            self.withHeaders = True
             return self
         if path == "text_with_headers":
             self.asText = True

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -76,10 +76,6 @@ class TextLog(Resource, ContextMixin):
             self.asText = True
             self.withHeaders = True
             return self
-        if path == "text_with_headers":
-            self.asText = True
-            self.withHeaders = True
-            return self
         if path == "iframe":
             self.iFrame = True
             return self

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -128,6 +128,10 @@ class TextLog(Resource, ContextMixin):
 
         # If plaintext is requested just return the content of the logfile
         if self.asText:
+            with_headers = "_with_headers" if self.withHeaders else ""
+            base_name = self.original.step.getName() + "_" + self.original.getName() + with_headers
+            base_name = base_name.replace(" ", "_") + ".txt"
+            req.setHeader("Content-Disposition", "inline; filename =\"" + base_name + "\"")
             return self.original.getTextWithHeaders() if self.withHeaders else self.original.getText()
 
 

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -28,6 +28,7 @@ from buildbot.status.web.base import IHTMLLog, HtmlResource, getCodebasesArg, Co
 from buildbot.status.web.xmltestresults import XMLTestResource
 from buildbot.status.web.jsontestresults import JSONTestResource
 
+import re
 
 class ChunkConsumer:
     implements(interfaces.IStatusLogConsumer)
@@ -134,7 +135,7 @@ class TextLog(Resource, ContextMixin):
         if self.asDownload:
             with_headers = "_with_headers" if self.withHeaders else ""
             base_name = self.original.step.getName() + "_" + self.original.getName() + with_headers
-            base_name = base_name.replace(" ", "_") + ".log"
+            base_name = re.sub(r'[\W]', '_', base_name) + ".log"
             req.setHeader("Content-Disposition", "attachment; filename =\"" + base_name + "\"")
             return self.original.getTextWithHeaders() if self.withHeaders else self.original.getText()
 

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -126,7 +126,7 @@ class TextLog(Resource, ContextMixin):
         if self.asText:
             with_headers = "_with_headers" if self.withHeaders else ""
             base_name = self.original.step.getName() + "_" + self.original.getName() + with_headers
-            base_name = base_name.replace(" ", "_") + ".txt"
+            base_name = base_name.replace(" ", "_") + ".log"
             req.setHeader("Content-Disposition", "inline; filename =\"" + base_name + "\"")
             return self.original.getTextWithHeaders() if self.withHeaders else self.original.getText()
 

--- a/www/templates/logs.html
+++ b/www/templates/logs.html
@@ -19,8 +19,20 @@
         <div class="container">
             <ul class="list-unstyled">
                 <li>
-                    <a href="{{ iframe_url }}" target="_blank">Open in new window</a>
+                  <a href="{{ iframe_url }}" target="_blank">Open in new window</a>
                 </li>
+                <li>
+                    /
+                </li>
+                <li>
+		  <a href="{{ plaintext_url }}" target="_blank">Download as plaintext </a>
+                </li>
+                <li>
+                    /
+                </li>
+		<li>
+		  <a href="{{ plaintext_with_headers_url }}" target="_blank">Download as plaintext with headers</a>
+		</li>
                 <li>
                     /
                 </li>

--- a/www/templates/logs.html
+++ b/www/templates/logs.html
@@ -19,19 +19,25 @@
         <div class="container">
             <ul class="list-unstyled">
                 <li>
-                  <a href="{{ iframe_url }}" target="_blank">Open in new window</a>
+                  <a href="{{ new_window_url }}" target="_blank">Open in new window without headers</a>
                 </li>
                 <li>
                     /
                 </li>
                 <li>
-		  <a href="{{ plaintext_url }}">Download without headers</a>
+                  <a href="{{ new_window_with_headers_url }}" target="_blank">Open in new window with headers</a>
+                </li>
+                <li>
+                    /
+                </li>
+                <li>
+		  <a href="{{ download_url }}">Download without headers</a>
                 </li>
                 <li>
                     /
                 </li>
 		<li>
-		  <a href="{{ plaintext_with_headers_url }}">Download with headers</a>
+		  <a href="{{ download_with_headers_url }}">Download with headers</a>
 		</li>
                 <li>
                     /

--- a/www/templates/logs.html
+++ b/www/templates/logs.html
@@ -25,13 +25,13 @@
                     /
                 </li>
                 <li>
-		  <a href="{{ plaintext_url }}" target="_blank">Download as plaintext </a>
+		  <a href="{{ plaintext_url }}">Download without headers</a>
                 </li>
                 <li>
                     /
                 </li>
 		<li>
-		  <a href="{{ plaintext_with_headers_url }}" target="_blank">Download as plaintext with headers</a>
+		  <a href="{{ plaintext_with_headers_url }}">Download with headers</a>
 		</li>
                 <li>
                     /


### PR DESCRIPTION
Added two links to the bottom bar of the logs which generate plaintext versions of the log with and without headers respectively.

Currently it does so in new tabs which could be changed by altering the "content-disposition" header to "attachment", but with copy/pasting currently disregarding newlines I think it's alright.
