### PR TITLE
Disable merging merging logic through configuraiton

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -673,7 +673,7 @@ class Builder(config.ReconfigurableServiceMixin,
 
         # then translate False and True properly
         if mergeRequests_fn is False:
-            mergeRequests_fn = None
+            mergeRequests_fn = Builder._skipMergeRequestFn
         elif mergeRequests_fn is True:
             mergeRequests_fn = Builder._defaultMergeRequestFn
 
@@ -702,6 +702,8 @@ class Builder(config.ReconfigurableServiceMixin,
             return req1.canBeMergedWith(req2)
         return False
 
+    def _skipMergeRequestFn(self, req1, req2):
+        return False
 
 class BuilderControl:
     implements(interfaces.IBuilderControl)

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -199,9 +199,6 @@ class BasicBuildChooser(BuildChooserBase):
     # fails the generic test.
 
     def __init__(self, bldr, master):
-        # By default katana  merges Requests
-        if bldr.config.mergeRequests is None:
-            bldr.config.mergeRequests = True
         BuildChooserBase.__init__(self, bldr, master)
 
         self.nextSlave = self.bldr.config.nextSlave
@@ -376,10 +373,6 @@ class KatanaBuildChooser(BasicBuildChooser):
         self.resumeBrdicts = None
 
     def setupNextBuildRequest(self, bldr, breq):
-        # by default katana merges buildrequests
-        if bldr.config.mergeRequests is None:
-            bldr.config.mergeRequests = True
-
         self.bldr = bldr
 
         self.nextSlave = self.bldr.config.nextSlave
@@ -621,7 +614,7 @@ class KatanaBuildChooser(BasicBuildChooser):
 
         for brdict in brdicts:
             req = yield self._getBuildRequestForBrdict(brdict)
-            canMerge = yield self.mergeRequestsFn(self.bldr, breq, req)
+            canMerge = self.mergeRequestsFn(self.bldr, breq, req)
             if canMerge and req.id != breq.id:
                 mergedRequests.append(req)
 

--- a/master/buildbot/test/unit/test_process_builder.py
+++ b/master/buildbot/test/unit/test_process_builder.py
@@ -154,7 +154,7 @@ class TestBuilderBuildCreation(BuilderMixin, unittest.TestCase):
 
         if fn == builder.Builder._defaultMergeRequestFn:
             fn = "default"
-        elif fn is cble:
+        elif fn is cble or fn == builder.Builder._skipMergeRequestFn:
             fn = 'callable'
         self.assertEqual(fn, expected)
 
@@ -165,7 +165,7 @@ class TestBuilderBuildCreation(BuilderMixin, unittest.TestCase):
         self.do_test_getMergeRequestsFn(None, True, 'default')
 
     def test_getMergeRequestsFn_global_False(self):
-        self.do_test_getMergeRequestsFn(None, False, None)
+        self.do_test_getMergeRequestsFn(None, False, 'callable')
 
     def test_getMergeRequestsFn_global_function(self):
         self.do_test_getMergeRequestsFn(None, 'callable', 'callable')
@@ -174,7 +174,7 @@ class TestBuilderBuildCreation(BuilderMixin, unittest.TestCase):
         self.do_test_getMergeRequestsFn(True, False, "default")
 
     def test_getMergeRequestsFn_builder_False(self):
-        self.do_test_getMergeRequestsFn(False, True, None)
+        self.do_test_getMergeRequestsFn(False, None, 'callable')
 
     def test_getMergeRequestsFn_builder_function(self):
         self.do_test_getMergeRequestsFn('callable', None, 'callable')

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -888,6 +888,7 @@ class TestKatanaMaybeStartBuildsOnBuilder(KatanaBuildRequestDistributorTestSetup
             can = bldr.config.canStartBuild
             return not can or can(*args)
         bldr.canStartBuild = canStartBuild
+        bldr.master = self.master
 
         return bldr
 

--- a/master/buildbot/test/util/katanabuildrequestdistributor.py
+++ b/master/buildbot/test/util/katanabuildrequestdistributor.py
@@ -32,6 +32,7 @@ class KatanaBuildRequestDistributorTestSetup(connector_component.ConnectorCompon
         self.master = self.botmaster.master = mock.Mock(name='master')
         self.master.db = self.db
         self.master.caches = cache.CacheManager()
+        self.master.config.mergeRequests = None
         self.processedBuilds = []
         self.mergedBuilds = []
         self.addRunningBuilds = False
@@ -161,6 +162,7 @@ class KatanaBuildRequestDistributorTestSetup(connector_component.ConnectorCompon
                                   addRunningBuilds)
 
         self.botmaster.builders[name] = bldr
+        bldr.master = self.master
         return bldr
 
     def getBuildSetTestData(self, xrange):


### PR DESCRIPTION
By default katana will merge compatible buildrequets, the following changes allows disable merging logic through configuration parameter c['mergeRequests'] = False
