### PR TITLE
Feature/custom build urls

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -823,11 +823,12 @@ class BuilderConfig:
         """
         Validates that customBuildUrls is a dictionary containing only strings and in the format {'name': 'url'}
         """
-        checkDictionaryContainsOnlyString = all(isinstance(key, str) and isinstance(value, str)
-                                                for key, value in self.customBuildUrls.iteritems())
+        def checkDictionaryContainsOnlyString():
+            return all(isinstance(key, str) and isinstance(value, str)
+                       for key, value in self.customBuildUrls.iteritems())
 
         if not isinstance(self.customBuildUrls, dict) or (
-            self.customBuildUrls and not checkDictionaryContainsOnlyString):
+            self.customBuildUrls and not checkDictionaryContainsOnlyString()):
             error("customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}")
 
     def getCustomBuildUrls(self, buildNumber):

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -713,7 +713,7 @@ class BuilderConfig:
             builddir=None, slavebuilddir=None, factory=None, category=None,
             nextSlave=None, nextBuild=None, locks=None, env=None,
             properties=None, mergeRequests=None, project=None, friendly_name=None, tags=[], description=None,
-            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls={}):
+            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls=None):
 
         # name is required, and can't start with '_'
         if not name or not isinstance(name, basestring):

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -713,7 +713,7 @@ class BuilderConfig:
             builddir=None, slavebuilddir=None, factory=None, category=None,
             nextSlave=None, nextBuild=None, locks=None, env=None,
             properties=None, mergeRequests=None, project=None, friendly_name=None, tags=[], description=None,
-            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls=None):
+            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls={}):
 
         # name is required, and can't start with '_'
         if not name or not isinstance(name, basestring):
@@ -821,14 +821,14 @@ class BuilderConfig:
 
     def _validateCustomBuildUrls(self):
         """
-        Validates that customBuildUrls  contains strings in the format {'name': 'url'}
+        Validates that customBuildUrls is a dictionary containing only strings and in the format {'name': 'url'}
         """
         checkDictionaryContainsOnlyString = all(isinstance(key, str) and isinstance(value, str)
                                                 for key, value in self.customBuildUrls.iteritems())
 
         if not isinstance(self.customBuildUrls, dict) or (
             self.customBuildUrls and not checkDictionaryContainsOnlyString):
-            error("customBuildUrls # URLs must be strings in the format {'name': 'url'}")
+            error("customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}")
 
     def getCustomBuildUrls(self, buildNumber):
         """

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -713,7 +713,7 @@ class BuilderConfig:
             builddir=None, slavebuilddir=None, factory=None, category=None,
             nextSlave=None, nextBuild=None, locks=None, env=None,
             properties=None, mergeRequests=None, project=None, friendly_name=None, tags=[], description=None,
-            canStartBuild=None, excludeGlobalFactory=False):
+            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls=None):
 
         # name is required, and can't start with '_'
         if not name or not isinstance(name, basestring):
@@ -816,6 +816,34 @@ class BuilderConfig:
 
         self.description = description
 
+        self.customBuildUrls = customBuildUrls or {}
+        self._validateCustomBuildUrls()
+
+    def _validateCustomBuildUrls(self):
+        """
+        Validates that customBuildUrls  contains strings in the format {'name': 'url'}
+        """
+        checkDictionaryContainsOnlyString = all(isinstance(key, str) and isinstance(value, str)
+                                                for key, value in self.customBuildUrls.iteritems())
+
+        if not isinstance(self.customBuildUrls, dict) or (
+            self.customBuildUrls and not checkDictionaryContainsOnlyString):
+            error("customBuildUrls # URLs must be strings in the format {'name': 'url'}")
+
+    def getCustomBuildUrls(self, buildNumber):
+        """
+        Format configured customBuildUrls to include the builder name and build number
+        :param buildNumber:
+        :type buildNumber: int
+        :return: customBuildUrls in the format [{'name': name, 'url': ur}]
+        """
+        customBuildUrls = []
+        for key, value in self.customBuildUrls.iteritems():
+            customBuildUrls.append({
+                'name': key,
+                'url': value.format(builderName=self.name, buildNumber=buildNumber)
+            })
+        return customBuildUrls
 
     def getConfigDict(self):
         # note: this method will disappear eventually - put your smarts in the

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -153,10 +153,10 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
         :return: BuilderConfig
         :rtype: buildbot.config.BuilderConfig
         """
-        builderConfig = None
-        if name in self.builders:
-            builderConfig=self.builders[name].config
-        return builderConfig
+        try:
+            return self.builders[name].config
+        except KeyError:
+            return None
 
     def startService(self):
         def buildRequestAdded(notif):

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -146,6 +146,18 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
     def getBuilders(self):
         return self.builders.values()
 
+    def getBuilderConfig(self, name):
+        """
+        Gets the BuilderConfiguration by it's name
+        :param name: builder name
+        :return: BuilderConfig
+        :rtype: buildbot.config.BuilderConfig
+        """
+        builderConfig = None
+        if name in self.builders:
+            builderConfig=self.builders[name].config
+        return builderConfig
+
     def startService(self):
         def buildRequestAdded(notif):
             self.maybeStartBuildsForBuilder(notif['buildername'])

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -245,6 +245,18 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
                 logs.append(loog)
         return logs
 
+    def getCustomUrls(self):
+        """
+        If the build is finished returns formated custom urls
+        :return: Configured custom build urls in the format [{'name': name, 'url': ur}]
+        """
+        customUrls = []
+        if self.isFinished():
+            builderConfig = self.builder.getBuilderConfig()
+            if builderConfig:
+                customUrls = builderConfig.getCustomBuildUrls(buildNumber=self.number)
+        return customUrls
+
     # subscription interface
 
     def subscribe(self, receiver, updateInterval=None):

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -469,6 +469,9 @@ class BuilderStatus(styles.Versioned):
     def getProject(self):
         return self.project
 
+    def getBuilderConfig(self):
+        return self.master.botmaster.getBuilderConfig(name=self.name)
+
     def getBuild(self, number):
         if number < 0:
             number = self.nextBuildNumber + number

--- a/master/buildbot/status/builder.py
+++ b/master/buildbot/status/builder.py
@@ -470,6 +470,10 @@ class BuilderStatus(styles.Versioned):
         return self.project
 
     def getBuilderConfig(self):
+        """
+        :return: Builder configuration associated with this builder
+        :rtype: buildbot.config.BuilderConfig
+        """
         return self.master.botmaster.getBuilderConfig(name=self.name)
 
     def getBuild(self, number):

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -288,6 +288,7 @@ class StatusResourceBuild(HtmlResource):
         cxt['path_to_codebases'] = path_to_codebases(req, project)
         cxt['build_url'] = path_to_build(req, b, False)
         cxt['slave_debug_url'] = self.getBuildmaster(req).config.slave_debug_url
+        cxt['customBuildUrls'] = b.getCustomUrls()
         codebases_arg = cxt['codebases_arg'] = getCodebasesArg(request=req)
 
         if not b.isFinished():

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1242,7 +1242,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         }
 
         self.assertRaisesConfigError(
-            "customBuildUrls # URLs must be strings in the format {'name': 'url'}",
+            "customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}",
             lambda : config.BuilderConfig(name='builder',
                                    slavename='s1',
                                    project="project",

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1211,6 +1211,43 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
             'slavenames': ['s2', 's1'],
         })
 
+    def test_customBuildUrls(self):
+        customBuildUrls={
+            'Open My Tests Tool': "http://tool.com/Build/View?builderName={builderName}&buildNumber={buildNumber}",
+            'name':'url2'
+        }
+
+        cfg = config.BuilderConfig(
+                name='builder',
+                slavename='s1',
+                project="project",
+                factory=self.factory,
+                customBuildUrls=customBuildUrls
+        )
+
+        expectedLinks = {
+            'Open My Tests Tool': "http://tool.com/Build/View?builderName=builder&buildNumber=1",
+            'name': 'url2'
+        }
+
+        for link in cfg.getCustomBuildUrls(1):
+            self.assertTrue('name' in link and 'url' in link)
+            self.assertTrue(link['name'] in customBuildUrls)
+            self.assertEquals(expectedLinks[link['name']], link['url'])
+
+    def test_customBuildUrlsFails(self):
+        customBuildUrls={
+            'Open My Tests Tool': "http://tool.com/Build/View?builderName={builderName}&buildNumber={buildNumber}",
+            1:2
+        }
+
+        self.assertRaisesConfigError(
+            "customBuildUrls # URLs must be strings in the format {'name': 'url'}",
+            lambda : config.BuilderConfig(name='builder',
+                                   slavename='s1',
+                                   project="project",
+                                   factory=self.factory,
+                                   customBuildUrls=customBuildUrls))
 
 
 class FakeService(config.ReconfigurableServiceMixin,

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1238,8 +1238,19 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
     def test_customBuildUrlsFails(self):
         customBuildUrls={
             'Open My Tests Tool': "http://tool.com/Build/View?builderName={builderName}&buildNumber={buildNumber}",
-            1:2
+            1: 2
         }
+
+        self.assertRaisesConfigError(
+            "customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}",
+            lambda : config.BuilderConfig(name='builder',
+                                   slavename='s1',
+                                   project="project",
+                                   factory=self.factory,
+                                   customBuildUrls=customBuildUrls))
+
+    def test_customBuildUrlsFailsInvalidValue(self):
+        customBuildUrls="Test Tool"
 
         self.assertRaisesConfigError(
             "customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}",

--- a/master/buildbot/test/unit/test_status_build.py
+++ b/master/buildbot/test/unit/test_status_build.py
@@ -84,6 +84,22 @@ class TestBuildProperties(unittest.TestCase):
         self.build_status.render("xyz")
         self.build_status.properties.render.assert_called_with("xyz")
 
+    def test_getCustomUrlsBuildFinished(self):
+        customUrls = [{'name': 'test tool', 'link': 'test link'}]
+        self.build_status.finished = True
+        builderConfig = mock.Mock()
+        builderConfig.getCustomBuildUrls = lambda buildNumber: customUrls
+        self.build_status.builder.getBuilderConfig = lambda: builderConfig
+        self.assertEquals(customUrls, self.build_status.getCustomUrls())
+
+    def test_getCustomUrlsBuildRunning(self):
+        customUrls = [{'name': 'test tool', 'link': 'test link'}]
+        self.build_status.finished = None
+        builderConfig = mock.Mock()
+        builderConfig.getCustomBuildUrls = lambda buildnumber: customUrls
+        self.build_status.builder.getBuilderConfig = lambda: builderConfig
+        self.assertEquals([], self.build_status.getCustomUrls())
+
 class TestBuildGetSourcestamps(unittest.TestCase):
     """
     Test that a BuildStatus has the necessary L{IProperties} methods and that

--- a/www/templates/build.html
+++ b/www/templates/build.html
@@ -366,6 +366,15 @@
                 <a class="small-head" href={{ request.uri+query_symbol+"debug=true" }}>Show hidden steps</a>
             </div>
             {% endif %}
+
+            {% for link in customBuildUrls %}
+            <div>
+                <a class="small-head" target="_blank" href='{{ link.url }}'>
+                    {{ link.name }}
+                </a>
+            </div>
+            {% endfor %}
+
             {% if result_css is defined and result_css == "failure" and slave_debug_url %}
             <div>
                 <a class="small-head" target="_blank" href={{ slave_debug_url }}>


### PR DESCRIPTION
Configure custom urls to show in build status when the build is finished.
the configuration is done master.cfg / BuilderConfig this is an example

```
BuilderConfig(name="my builder",
project="Example Project",
slavenames=["build-slave-04"],
startSlavenames=["build-slave-01"],
factory=factory1,
buildUrls={'Open Tests Tool':
"http://mytool.com/Build/View?"
"configurationUniqueName={builderName}&"
"buildNumber={buildNumber}"}
))
```
