### PR TITLE
Add an option to include the serverName in the customBuildUrls

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -833,9 +833,11 @@ class BuilderConfig:
 
     def getCustomBuildUrls(self, serverName, buildNumber):
         """
-        Format configured customBuildUrls to include the builder name and build number
+        Format configured customBuildUrls to include the server name, builder name and build number
         :param buildNumber:
         :type buildNumber: int
+        :parameter serverName:
+        :type serverName: str
         :return: customBuildUrls in the format [{'name': name, 'url': ur}]
         """
         customBuildUrls = []

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -831,7 +831,7 @@ class BuilderConfig:
             self.customBuildUrls and not checkDictionaryContainsOnlyString()):
             error("customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}")
 
-    def getCustomBuildUrls(self, buildNumber):
+    def getCustomBuildUrls(self, serverName, buildNumber):
         """
         Format configured customBuildUrls to include the builder name and build number
         :param buildNumber:
@@ -842,7 +842,7 @@ class BuilderConfig:
         for key, value in self.customBuildUrls.iteritems():
             customBuildUrls.append({
                 'name': key,
-                'url': value.format(builderName=self.name, buildNumber=buildNumber)
+                'url': value.format(serverName=serverName, builderName=self.name, buildNumber=buildNumber)
             })
         return customBuildUrls
 

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -254,7 +254,10 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         if self.isFinished():
             builderConfig = self.builder.getBuilderConfig()
             if builderConfig:
-                customUrls = builderConfig.getCustomBuildUrls(buildNumber=self.number)
+                customUrls = builderConfig.getCustomBuildUrls(
+                        serverName=self.master.status.getBuildbotURL(),
+                        buildNumber=self.number
+                )
         return customUrls
 
     # subscription interface

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1213,8 +1213,10 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
 
     def test_customBuildUrls(self):
         customBuildUrls={
-            'Open My Tests Tool': "http://tool.com/Build/View?builderName={builderName}&buildNumber={buildNumber}",
-            'name':'url2'
+            'Open My Tests Tool':
+                "http://tool.com/Build/View?katanaServer={serverName}"
+                "&builderName={builderName}&buildNumber={buildNumber}",
+            'name': 'url2'
         }
 
         cfg = config.BuilderConfig(
@@ -1226,11 +1228,11 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         )
 
         expectedLinks = {
-            'Open My Tests Tool': "http://tool.com/Build/View?builderName=builder&buildNumber=1",
+            'Open My Tests Tool': "http://tool.com/Build/View?katanaServer=test&builderName=builder&buildNumber=1",
             'name': 'url2'
         }
 
-        for link in cfg.getCustomBuildUrls(1):
+        for link in cfg.getCustomBuildUrls(serverName="test", buildNumber=1):
             self.assertTrue('name' in link and 'url' in link)
             self.assertTrue(link['name'] in customBuildUrls)
             self.assertEquals(expectedLinks[link['name']], link['url'])

--- a/master/buildbot/test/unit/test_status_build.py
+++ b/master/buildbot/test/unit/test_status_build.py
@@ -62,6 +62,14 @@ class TestBuildProperties(unittest.TestCase):
                                               self.BUILD_NUMBER)
         self.build_status.properties = mock.Mock()
 
+    def customUrlTestSetup(self):
+        customUrls = [{'name': 'test tool', 'link': 'test link'}]
+        builderConfig = mock.Mock()
+        builderConfig.getCustomBuildUrls = lambda serverName, buildNumber: customUrls
+        self.build_status.master.status.getBuildbotURL = lambda: "http://localhost/"
+        self.build_status.builder.getBuilderConfig = lambda: builderConfig
+        return customUrls
+
     def test_getProperty(self):
         self.build_status.getProperty('x')
         self.build_status.properties.getProperty.assert_called_with('x', None)
@@ -85,19 +93,13 @@ class TestBuildProperties(unittest.TestCase):
         self.build_status.properties.render.assert_called_with("xyz")
 
     def test_getCustomUrlsBuildFinished(self):
-        customUrls = [{'name': 'test tool', 'link': 'test link'}]
+        customUrls = self.customUrlTestSetup()
         self.build_status.finished = True
-        builderConfig = mock.Mock()
-        builderConfig.getCustomBuildUrls = lambda buildNumber: customUrls
-        self.build_status.builder.getBuilderConfig = lambda: builderConfig
         self.assertEquals(customUrls, self.build_status.getCustomUrls())
 
     def test_getCustomUrlsBuildRunning(self):
-        customUrls = [{'name': 'test tool', 'link': 'test link'}]
+        self.customUrlTestSetup()
         self.build_status.finished = None
-        builderConfig = mock.Mock()
-        builderConfig.getCustomBuildUrls = lambda buildnumber: customUrls
-        self.build_status.builder.getBuilderConfig = lambda: builderConfig
         self.assertEquals([], self.build_status.getCustomUrls())
 
 class TestBuildGetSourcestamps(unittest.TestCase):


### PR DESCRIPTION
Add an option to include the serverName in the custom url
"http://tool.com/Build/View?katanaServer={serverName}&builderName={builderName}&buildNumber={buildNumber}"
