### PR TITLE
Renamed serverName to buildbotUrl

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -831,20 +831,20 @@ class BuilderConfig:
             self.customBuildUrls and not checkDictionaryContainsOnlyString()):
             error("customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}")
 
-    def getCustomBuildUrls(self, serverName, buildNumber):
+    def getCustomBuildUrls(self, buildbotUrl, buildNumber):
         """
-        Format configured customBuildUrls to include the server name, builder name and build number
+        Format configured customBuildUrls to include the buildbot URL, builder name and build number
         :param buildNumber:
         :type buildNumber: int
-        :parameter serverName:
-        :type serverName: str
+        :parameter buildbotUrl:
+        :type buildbotUrl: str
         :return: customBuildUrls in the format [{'name': name, 'url': ur}]
         """
         customBuildUrls = []
         for key, value in self.customBuildUrls.iteritems():
             customBuildUrls.append({
                 'name': key,
-                'url': value.format(serverName=serverName, builderName=self.name, buildNumber=buildNumber)
+                'url': value.format(buildbotUrl=buildbotUrl, builderName=self.name, buildNumber=buildNumber)
             })
         return customBuildUrls
 

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -255,7 +255,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
             builderConfig = self.builder.getBuilderConfig()
             if builderConfig:
                 customUrls = builderConfig.getCustomBuildUrls(
-                        serverName=self.master.status.getBuildbotURL(),
+                        buildbotUrl=self.master.status.getBuildbotURL(),
                         buildNumber=self.number
                 )
         return customUrls

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1214,7 +1214,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
     def test_customBuildUrls(self):
         customBuildUrls={
             'Open My Tests Tool':
-                "http://tool.com/Build/View?katanaServer={serverName}"
+                "http://tool.com/Build/View?katanaUrl={buildbotUrl}"
                 "&builderName={builderName}&buildNumber={buildNumber}",
             'name': 'url2'
         }
@@ -1228,11 +1228,11 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         )
 
         expectedLinks = {
-            'Open My Tests Tool': "http://tool.com/Build/View?katanaServer=test&builderName=builder&buildNumber=1",
+            'Open My Tests Tool': "http://tool.com/Build/View?katanaUrl=test&builderName=builder&buildNumber=1",
             'name': 'url2'
         }
 
-        for link in cfg.getCustomBuildUrls(serverName="test", buildNumber=1):
+        for link in cfg.getCustomBuildUrls(buildbotUrl="test", buildNumber=1):
             self.assertTrue('name' in link and 'url' in link)
             self.assertTrue(link['name'] in customBuildUrls)
             self.assertEquals(expectedLinks[link['name']], link['url'])

--- a/master/buildbot/test/unit/test_status_build.py
+++ b/master/buildbot/test/unit/test_status_build.py
@@ -65,7 +65,7 @@ class TestBuildProperties(unittest.TestCase):
     def customUrlTestSetup(self):
         customUrls = [{'name': 'test tool', 'link': 'test link'}]
         builderConfig = mock.Mock()
-        builderConfig.getCustomBuildUrls = lambda serverName, buildNumber: customUrls
+        builderConfig.getCustomBuildUrls = lambda buildbotUrl, buildNumber: customUrls
         self.build_status.master.status.getBuildbotURL = lambda: "http://localhost/"
         self.build_status.builder.getBuilderConfig = lambda: builderConfig
         return customUrls


### PR DESCRIPTION
Code review feedback renamed serverName to buildbotUrl and katanaServer to katanaUrl since that's more specific to the value we are sending
