### PR TITLE
Add support for to pass buildUrl as parameter for customBuildUrls

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -831,7 +831,7 @@ class BuilderConfig:
             self.customBuildUrls and not checkDictionaryContainsOnlyString()):
             error("customBuildUrls must be a a dictionary containing only strings and in the format {'name': 'url'}")
 
-    def getCustomBuildUrls(self, buildbotUrl, buildNumber):
+    def getCustomBuildUrls(self, buildbotUrl, buildNumber, buildUrl):
         """
         Format configured customBuildUrls to include the buildbot URL, builder name and build number
         :param buildNumber:
@@ -844,7 +844,11 @@ class BuilderConfig:
         for key, value in self.customBuildUrls.iteritems():
             customBuildUrls.append({
                 'name': key,
-                'url': value.format(buildbotUrl=buildbotUrl, builderName=self.name, buildNumber=buildNumber)
+                'url': value.format(
+                        buildbotUrl=buildbotUrl,
+                        builderName=self.name,
+                        buildNumber=buildNumber,
+                        buildUrl=buildUrl)
             })
         return customBuildUrls
 

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -256,9 +256,14 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
             if builderConfig:
                 customUrls = builderConfig.getCustomBuildUrls(
                         buildbotUrl=self.master.status.getBuildbotURL(),
-                        buildNumber=self.number
+                        buildNumber=self.number,
+                        buildUrl=self.getBuildUrl()
                 )
         return customUrls
+
+    def getBuildUrl(self):
+        return self.master.status.getURLForThing(self)['path'] if 'path' in self.master.status.getURLForThing(
+            self) else ''
 
     # subscription interface
 

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1215,7 +1215,7 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         customBuildUrls={
             'Open My Tests Tool':
                 "http://tool.com/Build/View?katanaUrl={buildbotUrl}"
-                "&builderName={builderName}&buildNumber={buildNumber}",
+                "&builderName={builderName}&buildNumber={buildNumber}&buildUrl={buildUrl}",
             'name': 'url2'
         }
 
@@ -1228,11 +1228,12 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
         )
 
         expectedLinks = {
-            'Open My Tests Tool': "http://tool.com/Build/View?katanaUrl=test&builderName=builder&buildNumber=1",
+            'Open My Tests Tool': "http://tool.com/Build/View?katanaUrl=test&builderName=builder&buildNumber=1"
+                                  "&buildUrl=http://buildbot.com/build/1",
             'name': 'url2'
         }
 
-        for link in cfg.getCustomBuildUrls(buildbotUrl="test", buildNumber=1):
+        for link in cfg.getCustomBuildUrls(buildbotUrl="test", buildNumber=1, buildUrl="http://buildbot.com/build/1"):
             self.assertTrue('name' in link and 'url' in link)
             self.assertTrue(link['name'] in customBuildUrls)
             self.assertEquals(expectedLinks[link['name']], link['url'])

--- a/master/buildbot/test/unit/test_status_build.py
+++ b/master/buildbot/test/unit/test_status_build.py
@@ -65,8 +65,9 @@ class TestBuildProperties(unittest.TestCase):
     def customUrlTestSetup(self):
         customUrls = [{'name': 'test tool', 'link': 'test link'}]
         builderConfig = mock.Mock()
-        builderConfig.getCustomBuildUrls = lambda buildbotUrl, buildNumber: customUrls
+        builderConfig.getCustomBuildUrls = lambda buildbotUrl, buildNumber, buildUrl: customUrls
         self.build_status.master.status.getBuildbotURL = lambda: "http://localhost/"
+        self.build_status.master.status.getURLForThing = lambda build: "http://localhost/build/%d" % build.number
         self.build_status.builder.getBuilderConfig = lambda: builderConfig
         return customUrls
 


### PR DESCRIPTION
It was requested to pass the buildUrl  as paramter to the customBuildUrls 