### PR TITLE
model: save object state in LONGTEXT in MySQL

### DIFF
--- a/master/buildbot/db/migrate/versions/033_alter_object_state_json_type.py
+++ b/master/buildbot/db/migrate/versions/033_alter_object_state_json_type.py
@@ -1,0 +1,29 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Unity Technologies
+
+import sqlalchemy as sa
+from migrate import changeset
+from buildbot.db import types as bsa
+
+def upgrade(migrate_engine):
+    metadata = sa.MetaData()
+    metadata.bind = migrate_engine
+
+    changeset.alter_column(
+        sa.Column('value_json', bsa.LongText, nullable=False),
+        table='object_state',
+        metadata=metadata,
+        engine=migrate_engine
+    )

--- a/master/buildbot/db/model.py
+++ b/master/buildbot/db/model.py
@@ -19,6 +19,7 @@ import migrate.versioning.schema
 import migrate.versioning.repository
 from twisted.python import util, log
 from buildbot.db import base
+from buildbot.db import types as bsa
 
 try:
     from migrate.versioning import exceptions
@@ -322,7 +323,7 @@ class Model(base.DBConnectorComponent):
         # name for this value (local to the object)
         sa.Column("name", sa.String(length=255), nullable=False),
         # value, as a JSON string
-        sa.Column("value_json", sa.Text, nullable=False),
+        sa.Column("value_json", bsa.LongText, nullable=False),
     )
 
     # mastersconfig

--- a/master/buildbot/db/types.py
+++ b/master/buildbot/db/types.py
@@ -1,0 +1,31 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Unity Technologies
+
+"""Custom SQLAlchemy types."""
+
+from sqlalchemy import types as sa
+from sqlalchemy.dialects.mysql import LONGTEXT
+from sqlalchemy import TypeDecorator
+
+
+class LongText(TypeDecorator):
+    """Exposes a column as either TEXT in most dialects and LONGTEXT in MySQL."""
+
+    impl = None
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == 'mysql':
+            return LONGTEXT()
+        return sa.Text()

--- a/master/buildbot/test/unit/test_db_migrate_versions_033_alter_object_state_json_type.py
+++ b/master/buildbot/test/unit/test_db_migrate_versions_033_alter_object_state_json_type.py
@@ -1,0 +1,74 @@
+# This file is part of Buildbot.  Buildbot is free software: you can
+# redistribute it and/or modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright Buildbot Team Members
+
+import sqlalchemy as sa
+from twisted.trial import unittest
+from buildbot.test.util import migration
+from buildbot.db import types as bsa
+
+class Migration(migration.MigrateTestMixin, unittest.TestCase):
+
+    table_columns = [
+        ('changes', 'comments'),
+        ('buildset_properties', 'property_value'),
+    ]
+
+    def setUp(self):
+        return self.setUpMigrateTest()
+
+    def tearDown(self):
+        return self.tearDownMigrateTest()
+
+    def create_tables_thd(self, conn):
+        metadata = sa.MetaData()
+        metadata.bind = conn
+
+        objects = sa.Table("objects", metadata,
+                           # unique ID for this object
+                           sa.Column("id", sa.Integer, primary_key=True),
+                           # object's user-given name
+                           sa.Column('name', sa.String(128), nullable=False),
+                           # object's class name, basically representing a "type" for the state
+                           sa.Column('class_name', sa.String(128), nullable=False),
+                           )
+        objects.create()
+
+        object_state = sa.Table("object_state", metadata,
+                                # object for which this value is set
+                                sa.Column("objectid", sa.Integer, sa.ForeignKey('objects.id'), nullable=False),
+                                # name for this value (local to the object)
+                                sa.Column("name", sa.String(length=255), nullable=False),
+                                # value, as a JSON string
+                                sa.Column("value_json", sa.Text, nullable=False))
+        object_state.create()
+
+    # tests
+
+    def test_update(self):
+        def setup_thd(conn):
+            self.create_tables_thd(conn)
+
+        def verify_thd(conn):
+            metadata = sa.MetaData()
+            metadata.bind = conn
+
+            tbl = sa.Table('object_state', metadata, autoload=True)
+            col = getattr(tbl.c, 'value_json')
+
+            expected_type = bsa.LongText().dialect_impl(conn.dialect).load_dialect_impl(conn.dialect)
+
+            self.assertIsInstance(col.type, type(expected_type))
+
+        return self.do_test_migration(32, 33, setup_thd, verify_thd)


### PR DESCRIPTION
Poller data that exceeds 2^16 characters could not be saved in the
TEXT type that was previously used. A new type decorator has been
introduced that switches just MySQL to LONGTEXT, bringing its
storage space on par with other dialects' use of the TEXT type.