### PR TITLE
Fix restart

### DIFF
--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -314,8 +314,6 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
     @defer.inlineCallbacks
     def reconfigService(self, new_config):
-        yield self.changeServicesStateStarted()
-
         # check configured db
         if self.configured_db_url is None:
             self.configured_db_url = new_config.db['db_url']
@@ -337,6 +335,7 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         # reconfigure all the services
         try:
+            yield self.changeServicesStateStarted()
             yield config.ReconfigurableServiceMixin.reconfigService(self, new_config)
         except Exception:
             log.msg(Failure(), "WARNING: master may malfunction, correct the issues")

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -1173,7 +1173,7 @@ class KatanaBuildRequestDistributor(service.Service):
 
     @defer.inlineCallbacks
     def _procesBuildRequestsActivityLoop(self):
-        if self.master.changeServicesStateRunning():
+        if self.master.is_changing_services:
             return
 
         self.active = True
@@ -1184,7 +1184,7 @@ class KatanaBuildRequestDistributor(service.Service):
         while 1:
             yield self.activity_lock.acquire()
 
-            self.active = (not self.master.changeServicesStateRunning() and
+            self.active = (not self.master.is_changing_services and
                            self.running and (self.check_new_builds or self.check_resume_builds))
 
             # bail out if we shouldn't keep looping

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -1173,6 +1173,9 @@ class KatanaBuildRequestDistributor(service.Service):
 
     @defer.inlineCallbacks
     def _procesBuildRequestsActivityLoop(self):
+        if self.master.changeServicesStateRunning():
+            return
+
         self.active = True
 
         timer = timerLogStart(msg="_procesBuildRequestsActivityLoop ",
@@ -1181,7 +1184,9 @@ class KatanaBuildRequestDistributor(service.Service):
         while 1:
             yield self.activity_lock.acquire()
 
-            self.active = self.running and (self.check_new_builds or self.check_resume_builds)
+            self.active = (not self.master.changeServicesStateRunning() and
+                           self.running and (self.check_new_builds or self.check_resume_builds))
+
             # bail out if we shouldn't keep looping
             if not self.active:
                 self.activity_lock.release()

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -154,6 +154,9 @@ class FakeMaster(object):
     def getProject(self, name):
         pass
 
+    def changeServicesStateRunning(self):
+        pass
+
 
 # Leave this alias, in case we want to add more behavior later
 def make_master(wantDb=False, testcase=None, **kwargs):

--- a/master/buildbot/test/fake/fakemaster.py
+++ b/master/buildbot/test/fake/fakemaster.py
@@ -126,6 +126,7 @@ class FakeMaster(object):
         self.status = FakeStatus()
         self.status.master = self
         self.locks = {}
+        self.is_changing_services = None
 
     def getStatus(self):
         return self.status
@@ -152,9 +153,6 @@ class FakeMaster(object):
         return self.locks[lockid]
 
     def getProject(self, name):
-        pass
-
-    def changeServicesStateRunning(self):
         pass
 
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -679,6 +679,13 @@ class TestKatanaBuildRequestDistributorMaybeStartBuildsOn(KatanaBuildRequestDist
         yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
         self.assertEquals(self.processedBuilds, [('slave-01', [8])])
 
+    @defer.inlineCallbacks
+    def test_maybeStartOrResumeBuildsOnMasterIsReconfiguringServices(self):
+        yield self.generateBuildsWithDifferentPriorities()
+        self.master.changeServicesStateRunning.return_value = True
+        yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
+        self.assertEquals(self.processedBuilds, [])
+
 
 class TestKatanaBuildChooser(KatanaBuildRequestDistributorTestSetup, unittest.TestCase):
 

--- a/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/test/unit/test_process_buildrequestdistributor_katana.py
@@ -682,7 +682,7 @@ class TestKatanaBuildRequestDistributorMaybeStartBuildsOn(KatanaBuildRequestDist
     @defer.inlineCallbacks
     def test_maybeStartOrResumeBuildsOnMasterIsReconfiguringServices(self):
         yield self.generateBuildsWithDifferentPriorities()
-        self.master.changeServicesStateRunning.return_value = True
+        self.master.is_changing_services = True
         yield self.brd._maybeStartOrResumeBuildsOn(['bldr1'])
         self.assertEquals(self.processedBuilds, [])
 

--- a/master/buildbot/test/util/katanabuildrequestdistributor.py
+++ b/master/buildbot/test/util/katanabuildrequestdistributor.py
@@ -30,7 +30,7 @@ class KatanaBuildRequestDistributorTestSetup(connector_component.ConnectorCompon
         self.botmaster = mock.Mock(name='botmaster')
         self.botmaster.builders = {}
         self.master = self.botmaster.master = mock.Mock(name='master')
-        self.master.changeServicesStateRunning.return_value = False
+        self.master.is_changing_services = False
         self.master.db = self.db
         self.master.caches = cache.CacheManager()
         self.master.config.mergeRequests = None

--- a/master/buildbot/test/util/katanabuildrequestdistributor.py
+++ b/master/buildbot/test/util/katanabuildrequestdistributor.py
@@ -30,6 +30,7 @@ class KatanaBuildRequestDistributorTestSetup(connector_component.ConnectorCompon
         self.botmaster = mock.Mock(name='botmaster')
         self.botmaster.builders = {}
         self.master = self.botmaster.master = mock.Mock(name='master')
+        self.master.changeServicesStateRunning.return_value = False
         self.master.db = self.db
         self.master.caches = cache.CacheManager()
         self.master.config.mergeRequests = None


### PR DESCRIPTION
This prevents the master for processing new jobs while the services are starting/stopping. Fixing the issue "not valid scheduler: " during start up.