### PR TITLE
[WIP] Reconfig fixes, requires redeploy slave software:

### DIFF
--- a/master/buildbot/buildslave/__init__.py
+++ b/master/buildbot/buildslave/__init__.py
@@ -363,8 +363,9 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
                 if buildername in removedBuilderList:
                     selected_slave = build_status.getProperty('selected_slave')
                     result = INTERRUPTED if selected_slave and selected_slave == self.slavename else RETRY
-                    reason = 'Slave %s reconfigured, it has been removed from this builder.' % self.slavename
-                    yield build_status.stopBuild(reason=reason, result=result)
+                    reason = "Slave %s reconfigured, it has been removed from this builder." % self.slavename
+                    text = ["Katana has been reconfigured, it will automatically retry this build"]
+                    yield build_status.stopBuild(reason=reason, result=result, text=text)
 
     def updateSlave(self):
         """Called to add or remove builders after the slave has connected.

--- a/master/buildbot/buildslave/__init__.py
+++ b/master/buildbot/buildslave/__init__.py
@@ -32,6 +32,8 @@ from buildbot.process.properties import Properties
 from buildbot.util import subscription
 from buildbot.util.eventual import eventually
 from buildbot import config
+from buildbot.status.results import RETRY, INTERRUPTED
+from buildbot import interfaces
 
 class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
                         service.MultiService):
@@ -241,6 +243,7 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
         # update the attached slave's notion of which builders are attached.
         # This assumes that the relevant builders have already been configured,
         # which is why the reconfig_priority is set low in this class.
+        yield self.updateRemovedBuilders()
         yield self.updateSlave()
 
         yield config.ReconfigurableServiceMixin.reconfigService(self,
@@ -341,12 +344,34 @@ class AbstractBuildSlave(config.ReconfigurableServiceMixin, pb.Avatar,
         subject = "Katana: buildslave %s was lost" % self.slavename
         return self._mail_missing_message(subject, text)
 
+    @defer.inlineCallbacks
+    def updateRemovedBuilders(self):
+        if not self._old_builder_list:
+            return
+
+        current_builders = [b.name for b in self.botmaster.getBuildersForSlave(self.slavename)]
+        previous_builers = [name for name, slavebuilddir in self._old_builder_list]
+
+        if current_builders == previous_builers:
+            return
+
+        removedBuilderList = set(previous_builers) - set(current_builders)
+
+        if removedBuilderList and self.slave_status.runningBuilds:
+            for build_status in self.slave_status.runningBuilds:
+                buildername = build_status.getBuilder().getName()
+                if buildername in removedBuilderList:
+                    selected_slave = build_status.getProperty('selected_slave')
+                    result = INTERRUPTED if selected_slave and selected_slave == self.slavename else RETRY
+                    reason = 'Slave %s reconfigured, it has been removed from this builder.' % self.slavename
+                    yield build_status.stopBuild(reason=reason, result=result)
 
     def updateSlave(self):
         """Called to add or remove builders after the slave has connected.
 
         @return: a Deferred that indicates when an attached slave has
         accepted the new builders and/or released the old ones."""
+
         if self.slave:
             return self.sendBuilderList()
         else:

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -218,6 +218,7 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
             for n in removed_names:
                 slave = old_by_name[n]
 
+                yield slave.disconnect()
                 del self.slaves[n]
                 slave.master = None
                 slave.botmaster = None

--- a/master/buildbot/process/botmaster.py
+++ b/master/buildbot/process/botmaster.py
@@ -253,7 +253,7 @@ class BotMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         reason = "Builder %s has been removed" % builder.name
         for build_status in builder.builder_status.currentBuilds:
-            yield build_status.stopBuild(reason=reason, result=INTERRUPTED)
+            yield build_status.stopBuild(reason=reason, result=INTERRUPTED, text=[reason])
 
     @defer.inlineCallbacks
     def reconfigServiceBuilders(self, new_config):

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -558,7 +558,7 @@ class Build(properties.PropertiesMixin):
                 lock.stopWaitingUntilAvailable(self, access, d)
                 d.callback(None)
 
-    def stopBuild(self, reason="<no reason given>", result=None):
+    def stopBuild(self, reason="<no reason given>", result=None, text=None):
         # the idea here is to let the user cancel a build because, e.g.,
         # they realized they committed a bug and they don't want to waste
         # the time building something that they know will fail. Another
@@ -579,6 +579,7 @@ class Build(properties.PropertiesMixin):
 
         # TODO: validate result is valid katana result
         self.result = INTERRUPTED if result is None else result
+        self.text = text or self.text
 
         if self._acquiringLock:
             lock, access, d = self._acquiringLock
@@ -595,7 +596,7 @@ class Build(properties.PropertiesMixin):
         elif self.result == EXCEPTION:
             text = ["Build Caught Exception"]
         elif self.result == RETRY:
-            text = ["Build Caught Exception, Will Retry"]
+            text = self.text or ["Katana will automatically retry this build"]
         elif self.result == INTERRUPTED:
             text = ["Build Interrupted"]
         else:

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -558,7 +558,7 @@ class Build(properties.PropertiesMixin):
                 lock.stopWaitingUntilAvailable(self, access, d)
                 d.callback(None)
 
-    def stopBuild(self, reason="<no reason given>"):
+    def stopBuild(self, reason="<no reason given>", result=None):
         # the idea here is to let the user cancel a build because, e.g.,
         # they realized they committed a bug and they don't want to waste
         # the time building something that they know will fail. Another
@@ -572,15 +572,20 @@ class Build(properties.PropertiesMixin):
         # TODO: include 'reason' in this point event
         self.builder.builder_status.addPointEvent(['interrupt'])
         self.stopped = True
-        if self.currentStep:
-            self.currentStep.interrupt(reason)
+        interruptDeferred = defer.Deferred()
 
-        self.result = INTERRUPTED
+        if self.currentStep:
+            interruptDeferred = self.currentStep.interrupt(reason)
+
+        # TODO: validate result is valid katana result
+        self.result = INTERRUPTED if result is None else result
 
         if self._acquiringLock:
             lock, access, d = self._acquiringLock
             lock.stopWaitingUntilAvailable(self, access, d)
             d.callback(None)
+
+        return interruptDeferred
 
     def allStepsDone(self):
         if self.result == FAILURE or self.result == DEPENDENCY_FAILURE:

--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -544,11 +544,10 @@ class Build(properties.PropertiesMixin):
         log.msg("%s.lostRemote" % self)
         self.remote = None
         self.result = RETRY
-        self.text = ["lost", "remote"]
+        self.text = ["Katana will automatically retry this build"]
         if self.currentStep:
             # this should cause the step to finish.
             log.msg(" stopping currentStep", self.currentStep)
-            self.text += ["slave"]
             self.currentStep.addErrorResult(Failure(error.ConnectionLost()))
             self.currentStep.interrupt(Failure(error.ConnectionLost()))
         else:

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -138,7 +138,7 @@ class Builder(config.ReconfigurableServiceMixin,
         d = defer.maybeDeferred(lambda:
                 service.MultiService.stopService(self))
 
-        if self.building:
+        if  self.building and self.master.status.getBuilder(self.name):
             for b in self.building:
                 d.addCallback(self._resubmit_buildreqs, b.requests)
                 d.addErrback(log.err)

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -1023,6 +1023,9 @@ class LoggingBuildStep(BuildStep):
         if self.cmd:
             d = self.cmd.interrupt(reason)
             d.addErrback(log.err, 'while interrupting command')
+            return d
+
+        return defer.succeed(None)
 
     def checkDisconnect(self, f):
         f.trap(error.ConnectionLost)

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -520,6 +520,18 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         for s in self.steps:
             s.checkLogfiles()
 
+    @defer.inlineCallbacks
+    def stopBuild(self, reason, result=None):
+        c = interfaces.IControl(self.master)
+        buildername = self.getBuilder().getName()
+        bldrc = c.getBuilder(buildername)
+        if bldrc:
+            bldc = bldrc.getBuild(self.getNumber())
+            if bldc:
+                yield bldc.stopBuild(reason=reason, result=result)
+
+        defer.succeed(None)
+
     def cancelYourself(self):
         self.results = CANCELED
         self.started = util.now() if self.started is None else self.started

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -522,6 +522,9 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
 
     @defer.inlineCallbacks
     def stopBuild(self, reason, result=None):
+        if self.isFinished():
+            return
+
         c = interfaces.IControl(self.master)
         buildername = self.getBuilder().getName()
         bldrc = c.getBuilder(buildername)
@@ -529,8 +532,6 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
             bldc = bldrc.getBuild(self.getNumber())
             if bldc:
                 yield bldc.stopBuild(reason=reason, result=result)
-
-        defer.succeed(None)
 
     def cancelYourself(self):
         self.results = CANCELED

--- a/master/buildbot/status/build.py
+++ b/master/buildbot/status/build.py
@@ -521,7 +521,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
             s.checkLogfiles()
 
     @defer.inlineCallbacks
-    def stopBuild(self, reason, result=None):
+    def stopBuild(self, reason, result=None, text=None):
         if self.isFinished():
             return
 
@@ -531,7 +531,7 @@ class BuildStatus(styles.Versioned, properties.PropertiesMixin):
         if bldrc:
             bldc = bldrc.getBuild(self.getNumber())
             if bldc:
-                yield bldc.stopBuild(reason=reason, result=result)
+                yield bldc.stopBuild(reason=reason, result=result, text=text)
 
     def cancelYourself(self):
         self.results = CANCELED

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -314,10 +314,9 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
         """
         @rtype: L{BuilderStatus}
         """
-        if name in self.botmaster.builders:
-            return self.botmaster.builders[name].builder_status
+        builder = self.botmaster.builders.get(name)
 
-        return None
+        return builder.builder_status if builder else None
 
     def getSlaveNames(self):
         return self.botmaster.slaves.keys()
@@ -371,10 +370,11 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
 
         all_builds = []
         for bn in builder_names:
-            b = self.getBuilder(bn)
-            finished_builds = yield b.getFinishedBuildsByNumbers(buildnumbers=lastBuilds[bn],
-                                                                 results=results)
-            all_builds.extend(finished_builds)
+            builder = self.getBuilder(bn)
+            if builder:
+                finished_builds = yield builder.getFinishedBuildsByNumbers(buildnumbers=lastBuilds[bn],
+                                                                     results=results)
+                all_builds.extend(finished_builds)
 
         sorted_builds = sorted(all_builds, key=lambda build: build.finished, reverse=True)
         defer.returnValue(sorted_builds)

--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -153,12 +153,7 @@ class StopBuildActionResource(ActionResource):
         reason = ("The web-page 'Stop Build' button was pressed by "
                   "'%s': %s\n" % (html.escape(name), html.escape(comments)))
 
-        c = interfaces.IControl(self.getBuildmaster(req))
-        bldrc = c.getBuilder(self.build_status.getBuilder().getName())
-        if bldrc:
-            bldc = bldrc.getBuild(self.build_status.getNumber())
-            if bldc:
-                bldc.stopBuild(reason)
+        yield self.build_status.stopBuild(reason=reason)
 
         defer.returnValue(path_to_build(req, self.build_status))
 

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -44,3 +44,6 @@ class FakeBotMaster(service.MultiService):
 
     def maybeStartBuildsForSlave(self, slavename):
         self.buildsStartedForSlaves.append(slavename)
+
+    def maybeStartBuildsForBuilder(self, buildername):
+        pass

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -210,21 +210,21 @@ class TestBotMaster(unittest.TestCase):
     def test_reconfigServiceBuilders_add_remove(self):
         bc = config.BuilderConfig(name='bldr', factory=factory.BuildFactory(),
                             slavename='f', project="project")
-        self.new_config.builders = [ bc ]
+        self.new_config.builders = [bc]
 
         yield self.botmaster.reconfigServiceBuilders(self.new_config)
 
         bldr = self.botmaster.builders['bldr']
         self.assertIdentical(bldr.parent, self.botmaster)
         self.assertIdentical(bldr.master, self.master)
-        self.assertEqual(self.botmaster.builderNames, [ 'bldr' ])
+        self.assertEqual(self.botmaster.builderNames, ['bldr'])
 
-        self.new_config.builders = [ ]
+        self.new_config.builders = []
 
         yield self.botmaster.reconfigServiceBuilders(self.new_config)
 
         self.assertIdentical(bldr.parent, None)
-        self.assertIdentical(bldr.master, None)
+        self.assertTrue(bldr.master is not None)
         self.assertEqual(self.botmaster.builders, {})
         self.assertEqual(self.botmaster.builderNames, [])
 

--- a/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
+++ b/master/buildbot/test/unit/test_process_botmaster_BotMaster.py
@@ -120,6 +120,9 @@ class FakeBuildSlave(config.ReconfigurableServiceMixin, service.Service):
         self.reconfig_count += 1
         return defer.succeed(None)
 
+    def disconnect(self):
+        pass
+
 
 class FakeBuildSlave2(FakeBuildSlave):
     pass

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -411,7 +411,7 @@ class TestBuild(unittest.TestCase):
         self.assert_(b.currentStep is None)
         self.assertEqual(b.result, RETRY)
         self.assert_( ('interrupt', ('stop it',), {}) not in step.method_calls)
-        self.build.build_status.setText.assert_called_with(['Build Caught Exception, Will Retry'])
+        self.build.build_status.setText.assert_called_with(['lost', 'remote'])
         self.build.build_status.setResults.assert_called_with(RETRY)
 
     def testStopBuildWaitingForStepLocks(self):

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -378,7 +378,7 @@ class TestBuildRequest(unittest.TestCase):
         d = master.db.buildrequests.getBuildRequest(1)
 
         def checkCanceled(br):
-            self.assertEquals((br['complete'], br['results']), (False, BEGINNING))
+            self.assertEquals((br['complete'], br['results']), (True, CANCELED))
 
         d.addCallback(lambda brdict: buildrequest.BuildRequest.fromBrdict(master, brdict))
         d.addCallback(lambda breq: buildrequest.BuildRequestControl(None, breq))

--- a/master/buildbot/test/unit/test_steps_trigger.py
+++ b/master/buildbot/test/unit/test_steps_trigger.py
@@ -446,7 +446,7 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
         self.setupStep(trigger.Trigger(schedulerNames=['a'],
             waitForFinish=True))
         self.scheduler_a.result = FAILURE
-        self.expectOutcome(result=DEPENDENCY_FAILURE, status_text=['Dependency failed to build.'])
+        self.expectOutcome(result=DEPENDENCY_FAILURE, status_text=['Dependency failed to build'])
         self.expectTriggeredWith(a=({}, {'stepname': ('Trigger', 'Trigger')}, 1))
         self.expectTriggeredLinks('a')
         return self.runStep(expect_waitForFinish=True)
@@ -457,7 +457,7 @@ class TestTrigger(steps.BuildStepMixin, unittest.TestCase):
             waitForFinish=True))
         self.scheduler_b.exception = True
         self.expectOutcome(result=DEPENDENCY_FAILURE,
-                        status_text=['Dependency failed to build.'])
+                        status_text=['Dependency failed to build'])
         self.expectTriggeredWith(
             a=({}, {'stepname': ('Trigger', 'Trigger')}, 1),
             b=({}, {'stepname': ('Trigger', 'Trigger')}, 1))

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -158,9 +158,10 @@ class SlaveBuilder(pb.Referenceable, service.Service):
             log.msg(" .. but none was running")
             # Tell the master that the previous step is
             # completed as well.
-            d = self.prevStep.callRemote("complete", None)
-            d.addCallback(self.ackComplete)
-            d.addErrback(self._ackFailed, "sendComplete")
+            if self.prevStep:
+                d = self.prevStep.callRemote("complete", None)
+                d.addCallback(self.ackComplete)
+                d.addErrback(self._ackFailed, "sendComplete")
             return
         self.command.doInterrupt()
 
@@ -225,12 +226,16 @@ class SlaveBuilder(pb.Referenceable, service.Service):
         self.command = None
         if not self.running:
             log.msg(" but we weren't running, quitting silently")
-            return
+
         if self.remoteStep:
             self.remoteStep.dontNotifyOnDisconnect(self.lostRemoteStep)
             d = self.remoteStep.callRemote("complete", failure)
             d.addCallback(self.ackComplete)
-            d.addErrback(self._ackFailed, "sendComplete")
+            # Check ack if builder still attach to slave
+            if self.name in self.bot.builders.keys():
+                d.addErrback(self._ackFailed, "sendComplete")
+            else:
+                log.msg("Builder % has been detached %s" % self.name)
             self.prevStep = self.remoteStep
             self.remoteStep = None
 


### PR DESCRIPTION
[WIP] Reconfig fixes, requires redeploy slave software: 
- Requeue running builds when slaves gets detached from builder
- Update slave software to skip _ackFailed if the builder gets detached
- Refactor stopBuild to build_status
- Return the interrupt deferred to run actions async
- Builder handles reconfiguration of slaves and detached the ones that are no longer used
- Make sure we retry builds after build request are resubmitted