### PR TITLE
Added codebase information to pollers

### DIFF
--- a/master/buildbot/changes/custom/gitpoller.py
+++ b/master/buildbot/changes/custom/gitpoller.py
@@ -37,7 +37,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                  gitbin='git', usetimestamps=True,
                  category=None, project=None,
                  pollinterval=-2, fetch_refspec=None,
-                 encoding='utf-8'):
+                 encoding='utf-8', codebase=''):
 
         # for backward compatibility; the parameter used to be spelled with 'i'
         if pollinterval != -2:
@@ -57,6 +57,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
         self.usetimestamps = usetimestamps
         self.category = category
         self.project = project
+        self.codebase = codebase
         self.changeCount = 0
         self.lastRev = {}
 
@@ -304,6 +305,7 @@ class GitPoller(base.PollingChangeSource, StateMixin):
                 category=self.category,
                 project=self.project,
                 repository=self.repourl,
+                codebase=self.codebase,
                 src='git')
 
         self.lastRev[branchname] = newRev

--- a/master/buildbot/changes/custom/hgpoller.py
+++ b/master/buildbot/changes/custom/hgpoller.py
@@ -41,7 +41,8 @@ class HgPoller(base.PollingChangeSource, StateMixin):
                  workdir=None, pollInterval=10*60,
                  hgbin='hg', usetimestamps=True,
                  category=None, project='',
-                 encoding='utf-8', commits_checked=10000):
+                 encoding='utf-8', commits_checked=10000,
+                 codebase=''):
 
         self.repourl = repourl
         self.branches = branches
@@ -57,6 +58,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
         self.usetimestamps = usetimestamps
         self.category = category
         self.project = project
+        self.codebase = codebase
         self.commitInfo  = {}
         self.initLock = defer.DeferredLock()
         self.commits_checked = commits_checked
@@ -279,6 +281,7 @@ class HgPoller(base.PollingChangeSource, StateMixin):
                 category=self.category,
                 project=self.project,
                 repository=self.repourl,
+                codebase=self.codebase,
                 src='hg')
 
     def _getHead(self, branch):

--- a/master/buildbot/db/changes.py
+++ b/master/buildbot/db/changes.py
@@ -128,6 +128,25 @@ class ChangesConnectorComponent(base.DBConnectorComponent):
         d = self.db.pool.do(thd)
         return d
 
+    def getChangesGreaterThan(self, changeid):
+        assert changeid >= 0
+        def thd(conn):
+            # get rows from the 'changes' table
+            changes_tbl = self.db.model.changes
+            q = changes_tbl.select(
+                whereclause=(changes_tbl.c.changeid > changeid),
+                order_by=[sa.asc(changes_tbl.c.changeid)],
+            )
+            rp = conn.execute(q)
+            rows = rp.fetchall()
+            changes = [
+                self._chdict_from_change_row_thd(conn, row)
+                for row in rows
+            ]
+            return changes
+        d = self.db.pool.do(thd)
+        return d
+
     def getChangeUids(self, changeid):
         assert changeid >= 0
         def thd(conn):

--- a/master/buildbot/schedulers/base.py
+++ b/master/buildbot/schedulers/base.py
@@ -237,11 +237,13 @@ class BaseScheduler(service.MultiService, ComparableMixin, StateMixin, ScheduleO
 
             if change_filter and not change_filter.filter_change(change):
                 return
+
             if change.codebase not in self.codebases:
                 log.msg(format='change contains codebase %(codebase)s that is'
-                    'not processed by scheduler %(scheduler)s',
+                    'not processed by scheduler %(name)s',
                     codebase=change.codebase, name=self.name)
                 return
+
             if fileIsImportant:
                 try:
                     important = fileIsImportant(change)

--- a/master/buildbot/test/fake/fakedb.py
+++ b/master/buildbot/test/fake/fakedb.py
@@ -404,13 +404,8 @@ class FakeChangesComponent(FakeDBComponent):
             return defer.succeed(max(self.changes.iterkeys()))
         return defer.succeed(None)
 
-    def getChange(self, changeid):
-        try:
-            row = self.changes[changeid]
-        except KeyError:
-            return defer.succeed(None)
-
-        chdict = dict(
+    def _rowToChdict(self, row):
+        return dict(
                 changeid=row.changeid,
                 author=row.author,
                 files=row.files,
@@ -426,7 +421,20 @@ class FakeChangesComponent(FakeDBComponent):
                 codebase=row.codebase,
                 project=row.project)
 
-        return defer.succeed(chdict)
+    def getChange(self, changeid):
+        try:
+            row = self.changes[changeid]
+        except KeyError:
+            return defer.succeed(None)
+
+        return defer.succeed(self._rowToChdict(row))
+
+    def getChangesGreaterThan(self, changeid):
+        return defer.succeed([
+            self._rowToChdict(row)
+            for cid, row in sorted(self.changes.iteritems())
+            if cid > changeid
+        ])
 
     def getChangeUids(self, changeid):
         try:

--- a/master/buildbot/test/unit/test_changes_custom_poller.py
+++ b/master/buildbot/test/unit/test_changes_custom_poller.py
@@ -40,7 +40,7 @@ class TestCustomPoller(unittest.TestCase):
         self.changes_added = []
 
         def addChange(files=None, comments=None, author=None, revision=None,
-                      when_timestamp=None, branch=None, repository='', codebase=None,
+                      when_timestamp=None, branch=None, repository='', codebase='',
                       category='', project='', src=None):
             self.changes_added.append(Change(revision=revision, files=files,
                                  who=author, branch=branch, comments=comments,
@@ -54,19 +54,19 @@ class TestCustomPoller(unittest.TestCase):
         return [Change(revision=u'5553a6194a6393dfbec82f96654d52a76ddf844d', files=None,
                        who=u'dev3 <dev3@mail.com>', branch=u'1.0/dev', comments=u'list of changes3',
                        when=1421583649, category=None, project='',
-                       repository=repository, codebase=None),
+                       repository=repository, codebase=''),
                 Change(revision=u'b2e48cbab3f0753f99db833acff6ca18096854bd', files=None,
                        who=u'dev2 <dev2@mail.com>', branch=u'1.0/dev', comments=u'list of changes2',
                        when=1421667112, category=None, project='',
-                       repository=repository, codebase=None),
+                       repository=repository, codebase=''),
                 Change(revision=u'117b9a27b5bf65d7e7b5edb48f7fd59dc4170486', files=None,
                        who=u'dev1 <dev1@mail.com>', branch=u'1.0/dev', comments=u'list of changes1',
-                       when=1421667230, repository=repository, codebase=None),
+                       when=1421667230, repository=repository, codebase=''),
                 Change(revision=u'70fc4de2ff3828a587d80f7528c1b5314c51550e7', files=None,
                        who=u'dev4 <dev4@mail.com>', branch=u'trunkbookmark' if bookmark else u'trunk',
                        comments=u'list of changes4', when=1422983233,
                        category=None, project='', repository=repository,
-                       codebase=None)
+                       codebase='')
                 ]
 
     def getExpectedChangesHg(self, repository, bookmark=True):
@@ -75,7 +75,7 @@ class TestCustomPoller(unittest.TestCase):
                 Change(revision=u'68475k937dj69dk20567845jh9456726153hv47g7', files=None,
                        who=u'dev5 <dev5@mail.com>', branch=u'1.0/devOld', comments=u'list of changes5',
                        when=1421667231, category=None, project='',
-                       repository=repository, codebase=None),
+                       repository=repository, codebase=''),
                 ]
 
     def add_backwards_compatibility_with_db_commands(self):


### PR DESCRIPTION
This is necessary to make CI work (BranchScheduler and AnyBranchScheduler).

The current problem is that our pollers are not setting codebase information, but the code to trigger a new build is looking for that data in the database.

This seems to be fixed in buildbot, but in a major data API refactoring commit, so I just made a small fix for our version.