### PR TITLE
Fix: BuildRequest distributor skip processing some task while doing merges

### DIFF
--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -84,6 +84,7 @@ class BuildRequest(object):
     submittedAt = None
     brdict = None
     checkMerges = True
+    hasBeenMerged = False
     retries = 0
 
     @classmethod

--- a/master/buildbot/slow/loadtests/test_process_buildrequestdistributor_katana.py
+++ b/master/buildbot/slow/loadtests/test_process_buildrequestdistributor_katana.py
@@ -256,5 +256,5 @@ class TestKatanaBuildRequestDistributorUnderLoad(unittest.TestCase,
         yield self.profileAsyncFunc(18, self.brd._maybeStartOrResumeBuildsOn,
                                     new_builders=self.botmaster.builders.keys())
         self.assertEquals(len(self.processedBuilds), 199)
-        self.assertEquals(len(self.mergedBuilds), 388)
+        self.assertEquals(len(self.mergedBuilds), 398)
 


### PR DESCRIPTION
 Fix: Do not remove items from buildRequest list while doing merges, instead mark them as merged by assigning hasBeenMerged and checkMerges. 
    
Adjusted load test as more builds gets processed with this change,
