### PR TITLE
Fixes to speed up queue processing 

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -471,15 +471,6 @@ class Builder(config.ReconfigurableServiceMixin,
             defer.returnValue(False)
             return
 
-        # tell the remote that it's starting a build, too
-        try:
-            yield slavebuilder.remote.callRemote("startBuild")
-        except:
-            log.err(failure.Failure(), 'while calling remote startBuild:')
-            run_cleanups()
-            defer.returnValue(False)
-            return
-
         # create the BuildStatus object that goes with the Build
         if build_status is None:
             bs = self.builder_status.newBuild()

--- a/master/buildbot/process/slavebuilder.py
+++ b/master/buildbot/process/slavebuilder.py
@@ -189,10 +189,6 @@ class Ping:
             msg += " %s" % self.slavename
         return msg
 
-    def pingTimeout(self, value, timeout):
-        log.msg("ping %s timeout after %s secs" % (self.slavename, timeout))
-        raise Exception("Ping has timeout")
-
     def ping(self, remote, slavename, timeout=5):
         assert not self.running
         if not remote:
@@ -206,7 +202,7 @@ class Ping:
         # for this purpose is kind of silly.
         try:
             rd = remote.callRemote("print", "ping")
-            rd.addTimeout(timeout, reactor, onTimeoutCancel=self.pingTimeout)
+            rd.addTimeout(timeout, reactor)
             rd.addCallbacks(self._pong, self._ping_failed, errbackArgs=(remote,))
 
 

--- a/master/buildbot/process/slavebuilder.py
+++ b/master/buildbot/process/slavebuilder.py
@@ -191,6 +191,7 @@ class Ping:
 
     def pingTimeout(self, value, timeout):
         log.msg("ping %s timeout after %s secs" % (self.slavename, timeout))
+        raise Exception("Ping has timeout")
 
     def ping(self, remote, slavename, timeout=5):
         assert not self.running

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -112,13 +112,6 @@ class SlaveBuilder(pb.Referenceable, service.Service):
         if self.stopCommandOnShutdown:
             self.stopCommand()
 
-    # the following are Commands that can be invoked by the master-side
-    # Builder
-    def remote_startBuild(self):
-        """This is invoked before the first step of any new build is run.  It
-        doesn't do much, but masters call it so it's still here."""
-        pass
-
     def remote_startCommand(self, stepref, stepId, command, args):
         """
         This gets invoked by L{buildbot.process.step.RemoteCommand.start}, as

--- a/slave/buildslave/test/unit/test_bot.py
+++ b/slave/buildslave/test/unit/test_bot.py
@@ -234,9 +234,6 @@ class TestSlaveBuilder(command.CommandTestMixin, unittest.TestCase):
         d.addCallback(check)
         return d
 
-    def test_startBuild(self):
-        return self.sb.callRemote("startBuild")
-
     def test_startCommand(self):
         # set up a fake step to receive updates
         st = FakeStep()


### PR DESCRIPTION
- Remove `slavebuilder.remote.callRemote("startBuild")` as it is called right after the ping. If ping timeout we should just re-queue.
- Remove `pingTimeout`  so we always called the errorback. 
