### PR TITLE
Katana log improvements - save build logs

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -447,6 +447,9 @@ class Build(properties.PropertiesMixin):
         buildchain = yield master.db.buildrequests.getBuildRequestBuildChain(startbrid)
         defer.returnValue(buildchain)
 
+    def getBuildRequestID(self):
+        return self.requests[0].id if len(self.requests) > 0 else None
+
     def getNextStep(self):
         """This method is called to obtain the next BuildStep for this build.
         When it returns None (or raises a StopIteration exception), the build

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -579,11 +579,12 @@ class BuildStep(object, properties.PropertiesMixin):
         return {
             'buildbotURL': self.build.builder.master.config.buildbotURL,
             'buildNumber': self.build.build_status.number,
+            'buildRequestID': self.build.requests[0].id,
             'builderName': self.build.builder.name,
             'slaveName': self.build.slavename,
             'stepName': self.name,
             'stepNumber': self.step_status.step_number,
-            'sourcestamps': [ss.asDict() for ss in self.build.build_status.getSourceStamps()],
+            'sourcestamps': [ss.getDict() for ss in self.build.build_status.getSourceStamps()],
             'reason': self.build.build_status.reason,
             'owners': self.build.build_status.owners,
         }

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -113,9 +113,17 @@ class RemoteCommand(pb.Referenceable):
         # We will receive remote_update messages as the command runs.
         # We will get a single remote_complete when it finishes.
         # We should fire self.deferred when the command is done.
+        self._setManifest()
+
         d = self.remote.callRemote("startCommand", self, self.commandID,
-                                   self.remote_command, self.args, self.step.manifest)
+                                   self.remote_command, self.args)
         return d
+
+    def _setManifest(self):
+        if not self.args:
+            self.args = {'manifest': self.step.manifest}
+        elif isinstance(self.args, dict):
+            self.args['manifest'] = self.step.manifest
 
     def _finished(self, failure=None):
         if not self.active:

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -114,7 +114,7 @@ class RemoteCommand(pb.Referenceable):
         # We will get a single remote_complete when it finishes.
         # We should fire self.deferred when the command is done.
         d = self.remote.callRemote("startCommand", self, self.commandID,
-                                   self.remote_command, self.args)
+                                   self.remote_command, self.args, self.step.manifest)
         return d
 
     def _finished(self, failure=None):
@@ -524,6 +524,7 @@ class BuildStep(object, properties.PropertiesMixin):
 
         self._acquiringLock = None
         self.stopped = False
+        self.manifest = None
 
     def __new__(klass, *args, **kwargs):
         self = object.__new__(klass)
@@ -574,8 +575,23 @@ class BuildStep(object, properties.PropertiesMixin):
         return [(l.getLock(self.build.slavebuilder.slave), la) for l, la in initialLocks]
 
 
+    def getManifest(self):
+        return {
+            'buildbotURL': self.build.builder.master.config.buildbotURL,
+            'buildNumber': self.build.build_status.number,
+            'builderName': self.build.builder.name,
+            'slaveName': self.build.slavename,
+            'stepName': self.name,
+            'stepNumber': self.step_status.step_number,
+            'sourcestamps': [ss.asDict() for ss in self.build.build_status.getSourceStamps()],
+            'reason': self.build.build_status.reason,
+            'owners': self.build.build_status.owners,
+        }
+
+
     def startStep(self, remote):
         self.remote = remote
+        self.manifest = self.getManifest()
         self.deferred = defer.Deferred()
         # convert all locks into their real form
         self.locks = [(self.build.builder.botmaster.getLockByID(access.lockid), access) 

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -579,7 +579,7 @@ class BuildStep(object, properties.PropertiesMixin):
         return {
             'buildbotURL': self.build.builder.master.config.buildbotURL,
             'buildNumber': self.build.build_status.number,
-            'buildRequestID': self.build.requests[0].id,
+            'buildRequestID': self.build.getBuildRequestID(),
             'builderName': self.build.builder.name,
             'slaveName': self.build.slavename,
             'stepName': self.name,

--- a/master/buildbot/sourcestamp.py
+++ b/master/buildbot/sourcestamp.py
@@ -252,9 +252,11 @@ class SourceStamp(util.ComparableMixin, styles.Versioned):
         return text
 
     def asDict(self, status=None):
-        result = {'revision': self.revision, 'revision_short': self.revision[:12] if self.revision is not None else "",
-                  'hasPatch': self.patch is not None}
-        # Constant
+        result = {
+            'revision': self.revision,
+            'revision_short': self.revision[:12] if self.revision is not None else "",
+            'hasPatch': self.patch is not None
+        }
 
         # TODO(maruel): Make the patch content a suburl.
         if self.patch:

--- a/master/buildbot/sourcestamp.py
+++ b/master/buildbot/sourcestamp.py
@@ -252,13 +252,11 @@ class SourceStamp(util.ComparableMixin, styles.Versioned):
         return text
 
     def asDict(self, status=None):
-        result = {}
+        result = {'revision': self.revision, 'revision_short': self.revision[:12] if self.revision is not None else "",
+                  'hasPatch': self.patch is not None}
         # Constant
-        result['revision'] = self.revision
-        result['revision_short'] = self.revision[:12] if self.revision is not None else ""
 
         # TODO(maruel): Make the patch content a suburl.
-        result['hasPatch'] = self.patch is not None
         if self.patch:
             result['patch_level'] = self.patch[0]
             result['patch_body'] = self.patch[1]
@@ -280,6 +278,14 @@ class SourceStamp(util.ComparableMixin, styles.Versioned):
 
         result['totalChanges'] = self.totalChanges
         return result
+
+    def getDict(self):
+        return {
+            'revision': self.revision,
+            'branch': self.branch,
+            'repository': self.repository,
+            'codebase': self.codebase
+        }
 
     def __setstate__(self, d):
         styles.Versioned.__setstate__(self, d)

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -29,6 +29,9 @@ class FakeBuildStatus(properties.PropertiesMixin, mock.Mock):
     def getInterestedUsers(self):
         return []
 
+    def getSourceStamps(self):
+        return []
+
 components.registerAdapter(
         lambda build_status : build_status.properties,
         FakeBuildStatus, interfaces.IProperties)
@@ -45,6 +48,7 @@ class FakeBuild(properties.PropertiesMixin):
         pr.build = self
         self.requests = buildrequests
         self.steps = []
+        self.slavename = None
 
         self.sources = {}
         if props is None:

--- a/master/buildbot/test/fake/fakebuild.py
+++ b/master/buildbot/test/fake/fakebuild.py
@@ -70,6 +70,9 @@ class FakeBuild(properties.PropertiesMixin):
     def buildFinished(self, text, results):
         pass
 
+    def getBuildRequestID(self):
+        pass
+
 
 components.registerAdapter(
         lambda build : build.build_status.properties,

--- a/master/buildbot/test/unit/test_process_build.py
+++ b/master/buildbot/test/unit/test_process_build.py
@@ -82,6 +82,9 @@ class FakeBuildStatus(Mock):
         step_status = Mock()
         step_status.finished = None
         return step_status
+
+    def getSourceStamps(self):
+        return []
         
 class FakeBuilderStatus:
     implements(interfaces.IBuilderStatus)

--- a/master/buildbot/test/unit/test_status_mail.py
+++ b/master/buildbot/test/unit/test_status_mail.py
@@ -359,7 +359,7 @@ class TestMailNotifier(unittest.TestCase):
             
         ss1 = FakeSource(revision='111222', codebase='testlib1')
         ss2 = FakeSource(revision='222333', codebase='testlib2')
-        build.getSourceStamps.return_value = [ss1, ss2]
+        build.getSourceStamps = lambda: [ss1, ss2]
         
         mn.buildsetFinished(99, FAILURE)
 
@@ -426,7 +426,7 @@ class TestMailNotifier(unittest.TestCase):
         mn.master_status.getBuilder = fakeGetBuilder
             
         ss1 = FakeSource(revision='111222', codebase='testlib1')
-        build.getSourceStamps.return_value = [ss1]
+        build.getSourceStamps = lambda: [ss1]
         
         mn.buildsetFinished(99, FAILURE)
 
@@ -591,7 +591,7 @@ class TestMailNotifier(unittest.TestCase):
             b.builder = bldr
             b.results = 0
             ss = Mock(name='ss')
-            b.getSourceStamps.return_value = [ss]
+            b.getSourceStamps = lambda: [ss]
             ss.patch = None
             ss.changes = []
             b.getLogs.return_value = [ l ]

--- a/master/buildbot/test/unit/test_steps_find_previous_build.py
+++ b/master/buildbot/test/unit/test_steps_find_previous_build.py
@@ -18,6 +18,10 @@ class FakeSourceStamp(object):
     def asDict(self, includePatch = True):
         return self.__dict__.copy()
 
+    def getDict(self):
+        return self.__dict__.copy()
+
+
 class TestFindPreviousSuccessfulBuild(steps.BuildStepMixin, config.ConfigErrorsMixin, unittest.TestCase):
 
     def setUp(self):

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -60,7 +60,7 @@ class TestFileUpload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-1]
+            kwargs = command[-2]
             if commandName == 'uploadFile':
                 self.assertEquals(kwargs['slavesrc'], __file__)
                 writer = kwargs['writer']
@@ -92,7 +92,7 @@ class TestFileUpload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-1]
+            kwargs = command[-2]
             if commandName == 'uploadFile':
                 self.assertEquals(kwargs['slavesrc'], __file__)
                 writer = kwargs['writer']
@@ -129,7 +129,7 @@ class TestFileUpload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-1]
+            kwargs = command[-2]
             if commandName == 'uploadFile':
                 self.assertEquals(kwargs['slavesrc'], __file__)
                 writer = kwargs['writer']
@@ -199,7 +199,7 @@ class TestStringDownload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-1]
+            kwargs = command[-2]
             if commandName == 'downloadFile':
                 self.assertEquals(kwargs['slavedest'], 'hello.txt')
                 reader = kwargs['reader']
@@ -226,7 +226,7 @@ class TestJSONStringDownload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-1]
+            kwargs = command[-2]
             if commandName == 'downloadFile':
                 self.assertEquals(kwargs['slavedest'], 'hello.json')
                 reader = kwargs['reader']
@@ -257,7 +257,7 @@ class TestJSONPropertiesDownload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-1]
+            kwargs = command[-2]
             if commandName == 'downloadFile':
                 self.assertEquals(kwargs['slavedest'], 'props.json')
                 reader = kwargs['reader']

--- a/master/buildbot/test/unit/test_steps_transfer.py
+++ b/master/buildbot/test/unit/test_steps_transfer.py
@@ -60,7 +60,7 @@ class TestFileUpload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-2]
+            kwargs = command[-1]
             if commandName == 'uploadFile':
                 self.assertEquals(kwargs['slavesrc'], __file__)
                 writer = kwargs['writer']
@@ -92,7 +92,7 @@ class TestFileUpload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-2]
+            kwargs = command[-1]
             if commandName == 'uploadFile':
                 self.assertEquals(kwargs['slavesrc'], __file__)
                 writer = kwargs['writer']
@@ -129,7 +129,7 @@ class TestFileUpload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-2]
+            kwargs = command[-1]
             if commandName == 'uploadFile':
                 self.assertEquals(kwargs['slavesrc'], __file__)
                 writer = kwargs['writer']
@@ -199,7 +199,7 @@ class TestStringDownload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-2]
+            kwargs = command[-1]
             if commandName == 'downloadFile':
                 self.assertEquals(kwargs['slavedest'], 'hello.txt')
                 reader = kwargs['reader']
@@ -226,7 +226,7 @@ class TestJSONStringDownload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-2]
+            kwargs = command[-1]
             if commandName == 'downloadFile':
                 self.assertEquals(kwargs['slavedest'], 'hello.json')
                 reader = kwargs['reader']
@@ -257,7 +257,7 @@ class TestJSONPropertiesDownload(unittest.TestCase):
         for c in s.remote.method_calls:
             name, command, args = c
             commandName = command[3]
-            kwargs = command[-2]
+            kwargs = command[-1]
             if commandName == 'downloadFile':
                 self.assertEquals(kwargs['slavedest'], 'props.json')
                 reader = kwargs['reader']

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -112,7 +112,7 @@ class SlaveBuilder(pb.Referenceable, service.Service):
         if self.stopCommandOnShutdown:
             self.stopCommand()
 
-    def remote_startCommand(self, stepref, stepId, command, args):
+    def remote_startCommand(self, stepref, stepId, command, args, manifest=None):
         """
         This gets invoked by L{buildbot.process.step.RemoteCommand.start}, as
         part of various master-side BuildSteps, to start various commands
@@ -133,7 +133,7 @@ class SlaveBuilder(pb.Referenceable, service.Service):
             raise UnknownCommand, "unrecognized SlaveCommand '%s'" % command
         self.command = factory(self, stepId, args)
 
-        log.msg(" startCommand:%s [id %s]" % (command,stepId))
+        log.msg(" startCommand:%s [id %s]" % (command, stepId))
         self.remoteStep = stepref
         self.remoteStep.notifyOnDisconnect(self.lostRemoteStep)
         d = self.command.doStart()

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -117,12 +117,13 @@ class SlaveBuilder(pb.Referenceable, service.Service):
         if self.stopCommandOnShutdown:
             self.stopCommand()
 
-    def saveCommandOutputToLog(self, data):
+    def saveCommandOutputToLog(self, data, time):
         lines = data.splitlines()
         messages = []
 
         for line in lines:
             buildlog = dict(self.manifest) if self.manifest else {}
+            buildlog['time'] = time
             buildlog['message'] = line.strip()
             messages.append(buildlog)
 
@@ -307,7 +308,8 @@ class Bot(pb.Referenceable, service.MultiService):
 
         self.buildsLogsFile = BuildLogFile.fromFullPath(
             self.buildsLogsFilePath,
-            maxRotatedFiles=10
+            maxRotatedFiles=10,
+            rotateLength=20*1000*1000  # 20 M
         )
 
     def saveOutputToBuildLog(self, messages):

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -128,7 +128,7 @@ class SlaveBuilder(pb.Referenceable, service.Service):
 
         self.bot.saveOutputToBuildLog(messages)
 
-    def remote_startCommand(self, stepref, stepId, command, args, manifest=None):
+    def remote_startCommand(self, stepref, stepId, command, args):
         """
         This gets invoked by L{buildbot.process.step.RemoteCommand.start}, as
         part of various master-side BuildSteps, to start various commands
@@ -147,9 +147,9 @@ class SlaveBuilder(pb.Referenceable, service.Service):
             factory = registry.getFactory(command)
         except KeyError:
             raise UnknownCommand, "unrecognized SlaveCommand '%s'" % command
-        self.command = factory(self, stepId, args)
 
-        self.manifest = manifest
+        self.manifest = args.pop('manifest', {})
+        self.command = factory(self, stepId, args)
 
         log.msg(" startCommand:%s [id %s]" % (command, stepId))
         self.remoteStep = stepref

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -66,6 +66,7 @@ class SlaveBuilder(pb.Referenceable, service.Service):
     def __init__(self, name):
         #service.Service.__init__(self) # Service has no __init__ method
         self.setName(name)
+        self.manifest = None
 
     def __repr__(self):
         return "<SlaveBuilder '%s' at %d>" % (self.name, id(self))
@@ -121,7 +122,7 @@ class SlaveBuilder(pb.Referenceable, service.Service):
         messages = []
 
         for line in lines:
-            buildlog = dict(self.manifest)
+            buildlog = dict(self.manifest) if self.manifest else {}
             buildlog['message'] = line.strip()
             messages.append(buildlog)
 

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -34,6 +34,8 @@ from twisted.internet import reactor, defer, protocol, task, error
 from buildslave import util
 from buildslave.exceptions import AbandonChain
 
+from datetime import datetime
+
 if runtime.platformType == 'posix':
     from twisted.internet.process import Process
 
@@ -646,8 +648,8 @@ class RunProcess:
         logdata = []
         while self.buffered:
             # Grab the next bits from the buffer
-            logname, data = self.buffered.popleft()
-            self.builder.saveCommandOutputToLog(data)
+            logname, data, time = self.buffered.popleft()
+            self.builder.saveCommandOutputToLog(data, time)
 
             # If this log is different than the last one, then we have to send
             # out the message so far.  This is because the message is
@@ -699,7 +701,15 @@ class RunProcess:
         n = len(data)
 
         self.buflen += n
-        self.buffered.append((logname, data))
+
+        self.buffered.append(
+            (
+                logname,
+                data,
+                datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
+            )
+        )
+
         if self.buflen > self.BUFFER_SIZE:
             self._sendBuffers()
         elif not self.buftimer:

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -647,6 +647,7 @@ class RunProcess:
         while self.buffered:
             # Grab the next bits from the buffer
             logname, data = self.buffered.popleft()
+            self.builder.saveCommandOutputToLog(data)
 
             # If this log is different than the last one, then we have to send
             # out the message so far.  This is because the message is

--- a/slave/buildslave/test/fake/slavebuilder.py
+++ b/slave/buildslave/test/fake/slavebuilder.py
@@ -36,3 +36,5 @@ class FakeSlaveBuilder:
     def show(self):
         return pprint.pformat(self.updates)
 
+    def saveCommandOutputToLog(self, data):
+        pass

--- a/slave/buildslave/test/fake/slavebuilder.py
+++ b/slave/buildslave/test/fake/slavebuilder.py
@@ -36,5 +36,5 @@ class FakeSlaveBuilder:
     def show(self):
         return pprint.pformat(self.updates)
 
-    def saveCommandOutputToLog(self, data):
+    def saveCommandOutputToLog(self, data, time):
         pass


### PR DESCRIPTION
The initial part of the solution involves sending more information from katana to the agent about the actual build getting executed and storing this information including the command output to a log file