### PR TITLE
Fix logout 

### DIFF
--- a/master/buildbot/status/web/authz.py
+++ b/master/buildbot/status/web/authz.py
@@ -88,7 +88,7 @@ class BuildbotSession(SessionHandler):
         session = self.getSession(request, sessions)
         if session is not None:
             session.expire()
-            request.addCookie(self.key, None, expires=session.getExpiration(), path="/")
+            request.addCookie(self.key, '', expires=session.getExpiration(), path="/")
 
 class JsonWebTokens(SessionHandler):
     implements(ISessionHandler)


### PR DESCRIPTION
Twisted 17.5.0 no longer supports None parameter: 
this function request.addCookie(self.key, None, expires=session.getExpiration(), path="/") 
 breaks when trying to do 
cookie = _ensureBytes(k) + b"=" + _ensureBytes(v) in https://github.com/twisted/twisted/blob/trunk/src/twisted/web/http.py#L1152
