### PR TITLE
Handle issues serializing messages and exclude custom files

### DIFF
--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -270,9 +270,7 @@ class BuildLogFile(LogFile):
             json.dump(message, self)
             self.write(os.linesep)
         except:
-            log.err(failure.Failure(), "Failed to serialize message to json:")
-            log.msg("message:")
-            log.msg(message)
+            log.err(failure.Failure(), "Failed to serialize message to json: " + str(message))
 
     def write(self, data):
         """

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -260,11 +260,19 @@ class BuildLogFile(LogFile):
 
     def save(self, messages):
         for message in messages:
-            json.dump(message, self)
+            self.json_serialize(message)
             self.write(os.linesep)
 
         self.flush()
         self.handleFileRotation()
+
+    def json_serialize(self, message):
+        try:
+            json.dump(message, self)
+        except:
+            log.err(failure.Failure(), "Failed to serialize message to json:")
+            log.msg("message:")
+            log.msg(message)
 
     def write(self, data):
         """

--- a/slave/buildslave/bot.py
+++ b/slave/buildslave/bot.py
@@ -261,7 +261,6 @@ class BuildLogFile(LogFile):
     def save(self, messages):
         for message in messages:
             self.json_serialize(message)
-            self.write(os.linesep)
 
         self.flush()
         self.handleFileRotation()
@@ -269,6 +268,7 @@ class BuildLogFile(LogFile):
     def json_serialize(self, message):
         try:
             json.dump(message, self)
+            self.write(os.linesep)
         except:
             log.err(failure.Failure(), "Failed to serialize message to json:")
             log.msg("message:")

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -655,8 +655,10 @@ class RunProcess:
             logname, data, time = self.buffered.popleft()
             self.builder.saveCommandOutputToLog(data, time)
 
-            # exclude output from custom logfiles/artifacts
-            if not self.logfiles or not (isinstance(logname, tuple) and 'log' in logname):
+
+            # exclude saving the output from custom logfiles/artifacts
+            is_custom_log = isinstance(logname, tuple) and 'log' in logname  # exclude custom configured files
+            if not self.logfiles or not is_custom_log:
                 self.builder.saveCommandOutputToLog(data, time)
 
             # If this log is different than the last one, then we have to send

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -28,7 +28,7 @@ import stat
 from collections import deque
 from tempfile import NamedTemporaryFile
 
-from twisted.python import runtime, log
+from twisted.python import runtime, log, failure
 from twisted.internet import reactor, defer, protocol, task, error
 
 from buildslave import util
@@ -112,9 +112,13 @@ class LogFileWatcher:
         self.poller = None
 
     def stop(self):
-        self.poll()
-        if self.poller is not None:
-            self.poller.stop()
+        try:
+            self.poll()
+            if self.poller is not None:
+                self.poller.stop()
+        except:
+            log.err(failure.Failure(), 'LogFileWatcher failed to stop poller')
+
         if self.started:
             self.f.close()
 

--- a/slave/buildslave/runprocess.py
+++ b/slave/buildslave/runprocess.py
@@ -651,6 +651,10 @@ class RunProcess:
             logname, data, time = self.buffered.popleft()
             self.builder.saveCommandOutputToLog(data, time)
 
+            # exclude output from custom logfiles/artifacts
+            if not self.logfiles or not (isinstance(logname, tuple) and 'log' in logname):
+                self.builder.saveCommandOutputToLog(data, time)
+
             # If this log is different than the last one, then we have to send
             # out the message so far.  This is because the message is
             # transferred as a dictionary, which makes the ordering of keys


### PR DESCRIPTION
Exclude configured step files (we need to distinguish between log and artifacts), and handle possible errors on json.dump