### PR TITLE
Change page titles

### DIFF
--- a/master/buildbot/status/web/build.py
+++ b/master/buildbot/status/web/build.py
@@ -266,7 +266,7 @@ class StatusResourceBuild(HtmlResource):
         self.build_status = build_status
 
     def getPageTitle(self, request):
-        return ("Katana - %s Build #%d" %
+        return ("%s Build #%d" %
                 (self.build_status.getBuilder().getFriendlyName(),
                  self.build_status.getNumber()))
 

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -601,9 +601,7 @@ class BuildersResource(HtmlResource):
         HtmlResource.__init__(self)
         self.project = project
         self.numbuilds = numbuilds
-        branch_name = self.project.codebases[0].itervalues().next()['branch']
-        
-        self.pageTitle = branch_name + " Builders"
+        self.pageTitle = self.getBranchName() + "Builders"
 
     @defer.inlineCallbacks
     def content(self, req, cxt):
@@ -648,4 +646,12 @@ class BuildersResource(HtmlResource):
             return StatusResourceSelectedBuilders(self.getStatus(req))
 
         return HtmlResource.getChild(self, path, req)
+
+    def getBranchName(self):
+        branch_name = ''
+        if len(self.project.codebases) > 0:
+            branch = self.project.codebases[0].itervalues().next()['branch']
+            if len(branch) > 0:
+                branch_name = branch[0] + ' '
+        return branch_name
 

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -265,7 +265,7 @@ class StatusResourceBuilder(HtmlResource, BuildLineMixin):
         self.numbuilds = numbuilds
 
     def getPageTitle(self, request):
-        return "Katana - %s" % self.builder_status.getFriendlyName()
+        return "%s" % self.builder_status.getFriendlyName()
 
     def getSlavesJsonResource(self, filters, url, slaves_dict):
         if not slaves_dict:
@@ -595,13 +595,15 @@ class StatusResourceSelectedBuilders(HtmlResource, BuildLineMixin):
 
 # /builders
 class BuildersResource(HtmlResource):
-    pageTitle = "Katana - Builders"
     addSlash = True
 
     def __init__(self, project, numbuilds=15):
         HtmlResource.__init__(self)
         self.project = project
         self.numbuilds = numbuilds
+        branch_name = self.project.codebases[0].itervalues().next()['branch']
+        
+        self.pageTitle = branch_name + " Builders"
 
     @defer.inlineCallbacks
     def content(self, req, cxt):

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -595,13 +595,13 @@ class StatusResourceSelectedBuilders(HtmlResource, BuildLineMixin):
 
 # /builders
 class BuildersResource(HtmlResource):
+    pageTitle = "Builders"
     addSlash = True
 
     def __init__(self, project, numbuilds=15):
         HtmlResource.__init__(self)
         self.project = project
         self.numbuilds = numbuilds
-        self.pageTitle = self.getBranchName() + "Builders"
 
     @defer.inlineCallbacks
     def content(self, req, cxt):
@@ -646,12 +646,3 @@ class BuildersResource(HtmlResource):
             return StatusResourceSelectedBuilders(self.getStatus(req))
 
         return HtmlResource.getChild(self, path, req)
-
-    def getBranchName(self):
-        branch_name = ''
-        if len(self.project.codebases) > 0:
-            branch = self.project.codebases[0].itervalues().next()['branch']
-            if len(branch) > 0:
-                branch_name = branch[0] + ' '
-        return branch_name
-

--- a/master/buildbot/status/web/buildqueue.py
+++ b/master/buildbot/status/web/buildqueue.py
@@ -28,7 +28,7 @@ from buildbot.status.web.status_json import QueueJsonResource
 from buildbot.status.results import RESUME
 
 class BuildQueueResource(HtmlResource):
-    pageTitle = "Katana - Build Queue"
+    pageTitle = "Build Queue"
     addSlash = True
 
     def __init__(self):

--- a/master/buildbot/status/web/forms.py
+++ b/master/buildbot/status/web/forms.py
@@ -24,7 +24,7 @@ from buildbot.status.web.base import HtmlResource, getCodebasesArg, getRequestCh
 
 
 class FormsKatanaResource(HtmlResource):
-    pageTitle = "Katana - Forms"
+    pageTitle = "Forms"
 
     def content(self, request, cxt):
         cxt.update(content = "<h1>Page not found.</h1>")

--- a/master/buildbot/status/web/loginkatana.py
+++ b/master/buildbot/status/web/loginkatana.py
@@ -8,7 +8,7 @@ from twisted.python import log
 
 
 class LoginKatanaResource(HtmlResource):
-    pageTitle = "Katana - Login"
+    pageTitle = "Login"
 
     def content(self, req, cxt):
         status = self.getStatus(req)

--- a/master/buildbot/status/web/projects.py
+++ b/master/buildbot/status/web/projects.py
@@ -28,7 +28,7 @@ from buildbot.status.web.status_json import SingleProjectJsonResource
 
 
 class ProjectsResource(HtmlResource):
-    pageTitle = "Katana - Projects"
+    pageTitle = "Projects"
 
     def __init__(self, numbuilds=20):
         HtmlResource.__init__(self)
@@ -87,7 +87,7 @@ class ProjectsResource(HtmlResource):
     
 
 class CodeBasesResource(HtmlResource):
-    pageTitle = "Katana - Codebases"
+    pageTitle = "Codebases"
 
     def __init__(self, project, numbuilds=15):
         HtmlResource.__init__(self)
@@ -131,7 +131,7 @@ class CodeBasesResource(HtmlResource):
 
 # /builders/$project/comparison?branch_1=$branch1&branch_2=$branch2
 class BranchComparisonResource(HtmlResource):
-    pageTitle = "Katana - Branch Comparison"
+    pageTitle = "Branch Comparison"
 
     def __init__(self, project, numbuilds=15):
         HtmlResource.__init__(self)

--- a/master/buildbot/status/web/slaves.py
+++ b/master/buildbot/status/web/slaves.py
@@ -88,7 +88,7 @@ class OneBuildSlaveResource(HtmlResource, BuildLineMixin):
         self.slavename = slavename
 
     def getPageTitle(self, req):
-        return "Katana - %s" % self.slavename
+        return "%s" % self.slavename
 
     def getChild(self, path, req):
         s = self.getStatus(req)
@@ -176,7 +176,7 @@ class OneBuildSlaveResource(HtmlResource, BuildLineMixin):
 
 # /buildslaves
 class BuildSlavesResource(HtmlResource):
-    pageTitle = "Katana Build slaves"
+    pageTitle = "Build slaves"
     addSlash = True
 
     def content(self, request, cxt):

--- a/master/buildbot/status/web/step.py
+++ b/master/buildbot/status/web/step.py
@@ -25,7 +25,7 @@ from time import ctime
 
 # /builders/$builder/builds/$buildnum/steps/$stepname
 class StatusResourceBuildStep(HtmlResource):
-    pageTitle = "Katana - Build Step"
+    pageTitle = "Build Step"
     addSlash = True
 
     def __init__(self, build_status, step_status):


### PR DESCRIPTION
https://jira.hq.unity3d.com/browse/CDS-698

Removed 'Katana -' from page titles and added branch name to Builders page.
Should the branch name be shown on any other page?