### PR TITLE
Added proper exception handling for JSON test report data parsing

### DIFF
--- a/master/buildbot/status/web/jsontestresults.py
+++ b/master/buildbot/status/web/jsontestresults.py
@@ -50,48 +50,58 @@ class JSONTestResource(HtmlResource):
         cxt['splitext'] = splitext
         cxt['selectedproject'] = project
         cxt['removeTestFilter'] = removeTestFilter
+        cxt['results'] = {
+            0: 'Inconclusive',
+            1: 'NotRunnable',
+            2: 'Skipped',
+            3: 'Ignored',
+            4: 'Success',
+            5: 'Failed',
+            6: 'Error',
+            7: 'Cancelled'
+        }
+
+        json_data = None
+        error_message = None
 
         try:
-
             json_data = json.loads(self.log.getText())
 
-            if json_data is None:
-                raise ValueError("Json object is None")
+            if json_data is not None:
+                if 'summary' in json_data:
+                    success_count = json_data['summary']['successCount']
+                    total_count = json_data['summary']['testsCount']
+                    if success_count != 0 and total_count != 0:
+                        success_per = (float(success_count) / float(total_count)) * 100.0
+                        json_data['summary']['success_rate'] = success_per
 
-            cxt['data'] = json_data
+                json_data['filters'] = {
+                    'Inconclusive': True,
+                    'Skipped': False,
+                    'Ignored': False,
+                    'Success': False,
+                    'Failed': True,
+                    'Error': True,
+                    'Cancelled': True
+                }
 
-            if json_data['summary']:
-                success_count = json_data['summary']['successCount']
-                total_count = json_data['summary']['testsCount']
-                if success_count != 0 and total_count != 0:
-                    success_per = (float(success_count) / float(total_count)) * 100.0
-                    json_data['summary']['success_rate'] = success_per
-
-            json_data['filters'] = {
-                'Inconclusive': True,
-                'Skipped': False,
-                'Ignored': False,
-                'Success': False,
-                'Failed': True,
-                'Error': True,
-                'Cancelled': True
-            }
-
-            cxt['results'] = {
-                0: 'Inconclusive',
-                1: 'NotRunnable',
-                2: 'Skipped',
-                3: 'Ignored',
-                4: 'Success',
-                5: 'Failed',
-                6: 'Error',
-                7: 'Cancelled'
-            }
-
-        except ValueError as e:
-            log.msg("Error with parsing json: {0}".format(e))
+                cxt['data'] = json_data
+            else:
+                error_message = "[{0}] Error occurred while parsing JSON test report data" \
+                    .format(self.__class__.__name__)
         except KeyError as e:
-            log.msg("Key error in json: {0}".format(e))
+            error_message = "[{0}] Key error in json: {1}".format(self.__class__.__name__, e)
+        except:
+            import sys
+            import traceback
+            extype, ex, tb = sys.exc_info()
+            formatted = traceback.format_exception_only(extype, ex)[-1]
+            error_message = "[{0}] Unexpected exception caught while loading JSON test report data: {1}"\
+                .format(self.__class__.__name__, '\n\t'.join(formatted.splitlines()))
+
+        if error_message is not None:
+            cxt['data_error'] = error_message
+            log.msg(error_message)
 
         template = req.site.buildbot_service.templates.get_template("jsontestresults.html")
         return template.render(**cxt)

--- a/master/buildbot/status/web/jsontestresults.py
+++ b/master/buildbot/status/web/jsontestresults.py
@@ -17,6 +17,7 @@ import re
 from twisted.python import log
 from os.path import join, basename, splitext
 from buildbot.status.web.base import HtmlResource, path_to_builder, path_to_builders, path_to_codebases, path_to_build
+from twisted.python.failure import Failure
 
 
 class JSONTestResource(HtmlResource):
@@ -91,17 +92,17 @@ class JSONTestResource(HtmlResource):
                     .format(self.__class__.__name__)
         except KeyError as e:
             error_message = "[{0}] Key error in json: {1}".format(self.__class__.__name__, e)
-        except:
+        except Exception:
             import sys
             import traceback
             extype, ex, tb = sys.exc_info()
             formatted = traceback.format_exception_only(extype, ex)[-1]
             error_message = "[{0}] Unexpected exception caught while loading JSON test report data: {1}"\
                 .format(self.__class__.__name__, '\n\t'.join(formatted.splitlines()))
+            log.msg(Failure(), "Unexpected exception caught while loading JSON test report data")
 
         if error_message is not None:
             cxt['data_error'] = error_message
-            log.msg(error_message)
 
         template = req.site.buildbot_service.templates.get_template("jsontestresults.html")
         return template.render(**cxt)

--- a/master/buildbot/test/unit/test_status_web_status_jsontestresults.py
+++ b/master/buildbot/test/unit/test_status_web_status_jsontestresults.py
@@ -111,7 +111,8 @@ class TestJSONTestResource(unittest.TestCase):
         json_resource.content(req, ctx)
 
         self.assertTrue('data' not in ctx)
-        self.assertTrue('results' not in ctx)
+        self.assertTrue('data_error' in ctx)
+        self.assertTrue('results' in ctx)
         self.assertEqual(ctx['builder_name'], 'BuilderStatusFriendlyName')
         self.assertEqual(ctx['path_to_builder'], 'projects/Example%20Project/builders/BuilderStatusName')
         self.assertEqual(ctx['path_to_builders'], 'projects/Example%20Project/builders')
@@ -151,8 +152,8 @@ class TestJSONTestResource(unittest.TestCase):
         ctx = {}
         json_resource.content(req, ctx)
 
-        self.assertTrue(ctx['data'], data)
-
+        self.assertTrue(ctx['data_error'], data)
+        self.assertTrue('data' not in ctx)
         self.assertEqual(ctx['builder_name'], 'BuilderStatusFriendlyName')
         self.assertEqual(ctx['path_to_builder'], 'projects/Example%20Project/builders/BuilderStatusName')
         self.assertEqual(ctx['path_to_builders'], 'projects/Example%20Project/builders')

--- a/www/templates/test_results.html
+++ b/www/templates/test_results.html
@@ -13,55 +13,62 @@
     </script>
 {% endblock %}
 {% block content %}
-    <div class="top left"></div>
-    <div class="log-main" data-failed-tests="{{ data.summary.failedCount }}">
-        <div id="dataTablesFilter" class="fl-right top-filter-list">
-            <div id="CheckBoxesList" class="check-boxes-list">
-                {% for key, checked in data.filters.iteritems() %}
-                    <label for="{{ key }}input">{{ key }}</label>
-                    <input {{ 'checked=checked' if checked else '' }} type="checkbox" value="{{ key }}" id="{{ key }}input"/>
-                {% endfor %}
+    {% if data_error is defined %}
+        <div class="alert">{{ data_error }}</div>
+    {% endif %}
+    {% if data is defined %}
+        <div class="top left"></div>
+        <div class="log-main" data-failed-tests="{{ data.summary.failedCount }}">
+            <div id="dataTablesFilter" class="fl-right top-filter-list">
+                <div id="CheckBoxesList" class="check-boxes-list">
+                    {% for key, checked in data.filters.iteritems() %}
+                        <label for="{{ key }}input">{{ key }}</label>
+                        <input {{ 'checked=checked' if checked else '' }} type="checkbox" value="{{ key }}" id="{{ key }}input"/>
+                    {% endfor %}
+                </div>
+                <div class="dataTables_filter">
+                    <label class="input-label"></label>
+                    <input type="text" placeholder="Free text filter" id="filterinput"/>
+                </div>
+                <button class="grey-btn" id="submitFilter">Filter</button>
+                <button class="grey-btn" id="clearFilter">Clear</button>
             </div>
-            <div class="dataTables_filter">
-                <label class="input-label"></label>
-                <input type="text" placeholder="Free text filter" id="filterinput"/>
-            </div>
-            <button class="grey-btn" id="submitFilter">Filter</button>
-            <button class="grey-btn" id="clearFilter">Clear</button>
         </div>
-    </div>
 
-    <h1 class="main-head" id=":i18n:Summary">Summary</h1>
-    <table class="table table-katana" id="summaryTable">
-        <thead>
-        <tr>
-            <th class="txt-align-left first-child">All tests</th>
+        <h1 class="main-head" id=":i18n:Summary">Summary</h1>
+        <table class="table table-katana" id="summaryTable">
+            <thead>
+            <tr>
+                <th class="txt-align-left first-child">All tests</th>
+                {% for key in data.filters %}
+                    <th class="txt-align-left">{{ key }}</th>
+                {% endfor %}
+                <th class="txt-align-left">Success Rate</th>
+                <th class="txt-align-left">Time(s)</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% if data.summary.failedCount > 0 %}
+                <tr class="Failure">
+                    {% else %}
+                <tr class="Pass">
+            {% endif %}
+            <td class="txt-align-left first-child">{{ data.summary.testsCount }}</td>
             {% for key in data.filters %}
-                <th class="txt-align-left">{{ key }}</th>
+                {% set key = key.lower() + 'Count' %}
+                <td class="txt-align-left">{{ data.summary[key] if key in data.summary else 0 }}</td>
             {% endfor %}
-            <th class="txt-align-left">Success Rate</th>
-            <th class="txt-align-left">Time(s)</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% if data.summary.failedCount > 0 %}
-            <tr class="Failure">
-                {% else %}
-            <tr class="Pass">
-        {% endif %}
-        <td class="txt-align-left first-child">{{ data.summary.testsCount }}</td>
-        {% for key in data.filters %}
-            {% set key = key.lower() + 'Count' %}
-            <td class="txt-align-left">{{ data.summary[key] if key in data.summary else 0 }}</td>
-        {% endfor %}
 
-        <td class="txt-align-left">{{ '%0.2f' % data.summary.success_rate + '%' if data.summary.success_rate else '' }}</td>
-        <td class="txt-align-left" data-time="{{ data.summary.time }}"></td>
-        </tr>
-        </tbody>
-    </table>
+            <td class="txt-align-left">{{ '%0.2f' % data.summary.success_rate + '%' if data.summary.success_rate else '' }}</td>
+            <td class="txt-align-left" data-time="{{ data.summary.time }}"></td>
+            </tr>
+            </tbody>
+        </table>
 
-    {%- block suites -%}
-    {%- endblock -%}
+        {%- block suites -%}
+        {%- endblock -%}
+    {% endif %}
 
 {% endblock %}
+
+


### PR DESCRIPTION
Prevented JSON report from rendering if there is no `data` parsed or exception occurred.

Added handling of unexpected exceptions and rendering errors added to the report instead of Jinja error page.

 https://jira.hq.unity3d.com/browse/CDS-1408