### PR TITLE
Fix FindPreviousSuccessfulBuild with force_rebuild flag

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -685,10 +685,11 @@ class Builder(config.ReconfigurableServiceMixin,
             return True
         if req1.properties.has_key('selected_slave') or req2.properties.has_key('selected_slave'):
             return False
-        if self.getBoolProperty(req1, "force_rebuild") != self.getBoolProperty(req2, "force_rebuild"):
-            return False
-        if self.getBoolProperty(req1, "force_chain_rebuild") != self.getBoolProperty(req2, "force_chain_rebuild"):
-            return False
+        if not req1.isMergingWithPrevious:
+            if self.getBoolProperty(req1, "force_rebuild") != self.getBoolProperty(req2, "force_rebuild"):
+                return False
+            if self.getBoolProperty(req1, "force_chain_rebuild") != self.getBoolProperty(req2, "force_chain_rebuild"):
+                return False
         return True
 
     def _defaultMergeRequestFn(self, req1, req2):

--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -77,6 +77,9 @@ class BuildRequest(object):
     @ivar id: build request ID
 
     @ivar bsid: ID of the parent buildset
+
+    @ivar isMergingWithPrevious: automatic calculated property that is True
+    only during merge request for FindPreviousSuccessBuild and CheckArtifactExists
     """
 
     source = None
@@ -85,6 +88,7 @@ class BuildRequest(object):
     brdict = None
     checkMerges = True
     hasBeenMerged = False
+    isMergingWithPrevious = False
     retries = 0
 
     @classmethod

--- a/master/buildbot/steps/artifact.py
+++ b/master/buildbot/steps/artifact.py
@@ -86,9 +86,13 @@ class FindPreviousSuccessBuildMixin():
                 buildSetsProperties = yield master.db.buildsets.getBuildsetsProperties(buildSetIds)
                 for prevBuildRequest in prevBuildRequests:
                     req2 = self._getBuildRequest(master, prevBuildRequest, buildSets, buildSetsProperties, req1.sources)
-                    if (mergeRequestFn(build.builder, req1, req2)):
-                        log.msg("[brid: %d] previous successful build [%s] found with matching properties" % (build.requests[0].id, prevBuildRequest['brid']))
-                        defer.returnValue((PreviousBuildStatus.Found, prevBuildRequest))
+                    req1.isMergingWithPrevious = req2.isMergingWithPrevious = True
+                    try:
+                        if (mergeRequestFn(build.builder, req1, req2)):
+                            log.msg("[brid: %d] previous successful build [%s] found with matching properties" % (build.requests[0].id, prevBuildRequest['brid']))
+                            defer.returnValue((PreviousBuildStatus.Found, prevBuildRequest))
+                    finally:
+                        req1.isMergingWithPrevious = req2.isMergingWithPrevious = False
                 log.msg("[brid: %d] found %d previous successful builds , but merge function did not match" % (build.requests[0].id, len(prevBuildRequests)))
 
         log.msg("[brid: %d] found no previous successful builds" % build.requests[0].id)


### PR DESCRIPTION
Alexander Gubernsky found an issue where `force_rebuild` and `force_chain_rebuild` would be compared during find previous successful build, but it should not.

For example when doing the following steps:
1. Force Build
2. Non-Force Build
the seconds non-force build should be able to find force build from step 1, but it would not.

This fix adds `isMergingWithPrevious` field on `BuildRequest` that the merge function that can be used to difference between FindPreviousSuccessfulBuild and pending build requests merges and changes the default merge function to use that field.