### PR TITLE
Added a buildrequestmerger that merges things before they hit the database

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -716,7 +716,8 @@ class BuilderConfig:
             builddir=None, slavebuilddir=None, factory=None, category=None,
             nextSlave=None, nextBuild=None, locks=None, env=None,
             properties=None, mergeRequests=None, project=None, friendly_name=None, tags=[], description=None,
-            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls=None, build_tags=None):
+            canStartBuild=None, excludeGlobalFactory=False, customBuildUrls=None, build_tags=None,
+            mergeProperties=None):
 
         # name is required, and can't start with '_'
         if not name or not isinstance(name, basestring):
@@ -817,6 +818,10 @@ class BuilderConfig:
         self.project = project
         self.tags = tags
         self.build_tags = build_tags
+
+        # Additional properties that must match to allow buildrequests of
+        # this config to be merged
+        self.mergeProperties = mergeProperties or []
 
         self.description = description
 

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -1302,59 +1302,6 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
 
         return self.db.pool.do(thd)
 
-    def getTopLevelChainBrid(self, brid):
-        """
-        Given a build request id `brid`, find the top level build that started
-        the chain containing it.
-
-        :param str brid:
-        :return str:
-            Build request id
-        """
-        def thd(conn):
-            breq_tbl = self.db.model.buildrequests
-
-            q = sa.select(breq_tbl.c.startbrid) \
-                .where(breq_tbl.c.id == brid)
-
-            startbrid = conn.execute(q).fetchone().startbrid
-
-            # If startbrid is None, then `brid` IS the chain's top level build
-            return startbrid or brid
-
-        return self.db.pool.do(thd)
-
-    def getMergeTargetsInChain(self, startbrid, builderName):
-        """
-        :param str startbrid:
-            brid of top level build in a chain
-        :param str builderName:
-        :return tuple(str,str):
-            (buildsetid, brid) for all potential merge target buildrequests in
-            the same chain with the same `builderName`
-        """
-        def thd(conn):
-            # Select buildrequests `buildsetit` and `brid`
-            # q = sa.select(breq_tbl.c.buildsetid, breq_tbl.c.id) \
-
-            # For builders in the same chain
-            #     .where(breq_tbl.c.startbrid == startbrid) \
-
-            # With the same name
-            #     .where(breq_tbl.c.buildername == builderName) \
-
-            # That were not merged themselves (only merge against one / main target)
-            #     .where(breq_tbl.c.mergebrid == None) \
-            breq_tbl = self.db.model.buildrequests
-            q = sa.select(breq_tbl.c.buildsetid, breq_tbl.c.id) \
-                .where(breq_tbl.c.startbrid == startbrid) \
-                .where(breq_tbl.c.buildername == builderName) \
-                .where(breq_tbl.c.mergebrid == None)
-            res = conn.execute(q)
-            return res.fetchall() or []
-
-        return self.db.pool.do(thd)
-
     def _brdictFromRow(self, row, master_objectid):
         claimed = mine = False
         claimed_at = None

--- a/master/buildbot/db/buildrequests.py
+++ b/master/buildbot/db/buildrequests.py
@@ -1302,6 +1302,59 @@ class BuildRequestsConnectorComponent(base.DBConnectorComponent):
 
         return self.db.pool.do(thd)
 
+    def getTopLevelChainBrid(self, brid):
+        """
+        Given a build request id `brid`, find the top level build that started
+        the chain containing it.
+
+        :param str brid:
+        :return str:
+            Build request id
+        """
+        def thd(conn):
+            breq_tbl = self.db.model.buildrequests
+
+            q = sa.select(breq_tbl.c.startbrid) \
+                .where(breq_tbl.c.id == brid)
+
+            startbrid = conn.execute(q).fetchone().startbrid
+
+            # If startbrid is None, then `brid` IS the chain's top level build
+            return startbrid or brid
+
+        return self.db.pool.do(thd)
+
+    def getMergeTargetsInChain(self, startbrid, builderName):
+        """
+        :param str startbrid:
+            brid of top level build in a chain
+        :param str builderName:
+        :return tuple(str,str):
+            (buildsetid, brid) for all potential merge target buildrequests in
+            the same chain with the same `builderName`
+        """
+        def thd(conn):
+            # Select buildrequests `buildsetit` and `brid`
+            # q = sa.select(breq_tbl.c.buildsetid, breq_tbl.c.id) \
+
+            # For builders in the same chain
+            #     .where(breq_tbl.c.startbrid == startbrid) \
+
+            # With the same name
+            #     .where(breq_tbl.c.buildername == builderName) \
+
+            # That were not merged themselves (only merge against one / main target)
+            #     .where(breq_tbl.c.mergebrid == None) \
+            breq_tbl = self.db.model.buildrequests
+            q = sa.select(breq_tbl.c.buildsetid, breq_tbl.c.id) \
+                .where(breq_tbl.c.startbrid == startbrid) \
+                .where(breq_tbl.c.buildername == builderName) \
+                .where(breq_tbl.c.mergebrid == None)
+            res = conn.execute(q)
+            return res.fetchall() or []
+
+        return self.db.pool.do(thd)
+
     def _brdictFromRow(self, row, master_objectid):
         claimed = mine = False
         claimed_at = None

--- a/master/buildbot/db/buildsets.py
+++ b/master/buildbot/db/buildsets.py
@@ -31,7 +31,10 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
     # Documentation is in developer/database.rst
 
     def addBuildset(self, sourcestampsetid, reason, properties, triggeredbybrid=None,
-                    builderNames=None, external_idstring=None,  _reactor=reactor):
+                    builderNames=None, external_idstring=None, _reactor=reactor, breqsToMerge=None):
+        if breqsToMerge is None:
+            breqsToMerge = {}
+
         def thd(conn):
             priority = Priority.Default
             buildsets_tbl = self.db.model.buildsets
@@ -89,11 +92,12 @@ class BuildsetsConnectorComponent(base.DBConnectorComponent):
             for buildername in builderNames:
                 self.check_length(br_tbl.c.buildername, buildername)
                 res = conn.execute(ins,
-                    dict(buildsetid=bsid, buildername=buildername, priority=priority,
-                        claimed_at=0, claimed_by_name=None,
-                        claimed_by_incarnation=None, complete=0, results=-1,
-                        submitted_at=submitted_at, complete_at=None,
-                        triggeredbybrid=triggeredbybrid, startbrid=startbrid))
+                                   dict(buildsetid=bsid, buildername=buildername, priority=priority,
+                                        claimed_at=0, claimed_by_name=None,
+                                        claimed_by_incarnation=None, complete=0, results=-1,
+                                        submitted_at=submitted_at, complete_at=None,
+                                        triggeredbybrid=triggeredbybrid, startbrid=startbrid,
+                                        mergeBrid=breqsToMerge.get(buildername, None)))
 
                 brids[buildername] = res.inserted_primary_key[0]
 

--- a/master/buildbot/master.py
+++ b/master/buildbot/master.py
@@ -26,6 +26,7 @@ from twisted.python.failure import Failure
 
 import buildbot
 import buildbot.pbmanager
+from buildbot.process.buildrequestmerger import BuildRequestMerger
 from buildbot.util import subscription, epoch2datetime
 from buildbot.status.master import Status
 from buildbot.changes import changes
@@ -150,6 +151,9 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
 
         self.status = Status(self)
         self.status.setServiceParent(self)
+
+        self.buildrequest_merger = BuildRequestMerger(self)
+        self.buildrequest_merger.setServiceParent(self)
 
     # setup and reconfig handling
 
@@ -580,7 +584,7 @@ class BuildMaster(config.ReconfigurableServiceMixin, service.MultiService):
         including returning a Deferred, but also potentially triggers the
         resulting builds.
         """
-        d = self.db.buildsets.addBuildset(**kwargs)
+        d = self.buildrequest_merger.addBuildset(**kwargs)
         def notify((bsid,brids)):
             log.msg("added buildset %d to database" % bsid)
             # note that buildset additions are only reported on this master

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -148,10 +148,15 @@ class BuildChooserBase(object):
         if breq is None:
             return None
 
+        return self._getBrdictForBuildRequestId(breq.id)
+
+    def _getBrdictForBuildRequestId(self, brid, pendingBrdicts=None):
+        # Turn a BuildRequest id back into a brdict. This operates from the
+        # cache, which must be set up once via _fetchUnclaimedBrdicts
+
         if pendingBrdicts is None:
             pendingBrdicts = self.unclaimedBrdicts
-        
-        brid = breq.id
+
         for brdict in pendingBrdicts:
             if brid == brdict['brid']:
                 return brdict

--- a/master/buildbot/process/buildrequestmerger.py
+++ b/master/buildbot/process/buildrequestmerger.py
@@ -106,7 +106,7 @@ class BuildRequestMerger(config.ReconfigurableServiceMixin, service.Service):
         """
         # Get sourcestamp information for this. It is safe to this multiple times
         # because `sourcestamps.getSourceStamps` is cached.
-        sourcestamps = self.master.db.sourcestamps.getSourceStamps(
+        sourcestamps = yield self.master.db.sourcestamps.getSourceStamps(
             sourcestampsetid)
 
         # Get an initial list of all breqs of the same name, in the same chain

--- a/master/buildbot/process/buildrequestmerger.py
+++ b/master/buildbot/process/buildrequestmerger.py
@@ -1,0 +1,248 @@
+import json
+import time
+
+from twisted.application import service
+from twisted.internet import reactor
+from twisted.python import log
+import sqlalchemy as sa
+
+from buildbot import config
+from buildbot.process.buildrequest import Priority
+from buildbot.util.lru import LRUCache
+
+
+class BuildRequestMerger(config.ReconfigurableServiceMixin, service.Service):
+    # Basic list of properties that must match for a buildrequest to be merged
+    # BuilderConfigs can define additional properties (see _propertiesMatch)
+    BASE_MERGE_PROPERTIES = ['force_rebuild', 'force_chain_rebuild']
+
+    def __init__(self, master):
+        self.master = master
+        self.properties_cache = LRUCache(
+            miss_fn=self.__propertiesCacheMissFn, max_size=20000)
+
+    def addBuildset(self,
+                    sourcestampsetid,
+                    reason,
+                    properties,
+                    triggeredbybrid=None,
+                    builderNames=None,
+                    external_idstring=None,
+                    _reactor=reactor):
+        """
+        Wrapper around buildsets.addBuildset that does merging before
+        buildrequests hit the db
+
+        ..seealso:: buildsets.addBuildset
+        """
+        start = time.time()
+
+        buildsetLog = {
+            'name': 'addBuildset',
+            'description': 'Log merges done while adding new buildsets',
+            'sourcestampsetid': sourcestampsetid,
+            'builderNames': builderNames,
+        }
+
+        codebase, branch, revision = self._getSourceStampInfo(sourcestampsetid)
+
+        buildsetLog['_getSourceStampInfo'] = {
+            'elapsed': time.time() - start,
+            'codebase': codebase,
+            'branch': branch,
+            'revision': revision,
+        }
+
+        # Find the priority for this buildset
+        priority = Priority.Default
+        if 'priority' in properties:
+            priority_property = properties.get('priority')[0]
+            priority = priority_property if priority_property and int(
+                priority_property) > 0 else Priority.Default
+
+        # For every builderName in this buildset, check which ones can be merged
+        breqsToMerge = {}
+        for builderName in builderNames:
+            builderMergeStart = time.time()
+            mergeBrid = self._getMergeBrid(
+                self.master.botmaster.builders[builderName], builderName,
+                priority, codebase, branch, revision, properties)
+            if mergeBrid:
+                breqsToMerge[builderName] = mergeBrid
+
+            buildsetLog[builderName] = {
+                'elapsed': time.time() - builderMergeStart,
+                'mergeBrid': mergeBrid
+            }
+
+        buildsetLog['elapsed'] = time.time() - start
+
+        log.msg(json.dumps(buildsetLog))
+
+        return self.master.db.buildsets.addBuildset(
+            sourcestampsetid=sourcestampsetid,
+            reason=reason,
+            properties=properties,
+            triggeredbybrid=triggeredbybrid,
+            builderNames=builderNames,
+            breqsToMerge=breqsToMerge,
+            external_idstring=external_idstring,
+            _reactor=_reactor, )
+
+    def _getSourceStampInfo(self, sourcestampsetid):
+        """
+        :param str sourcestampsetid:
+        :return tuple(str,str,str):
+            (codebase, branch, revision) for the given `sourcestampsetid`
+        """
+        ss_tbl = self.master.db.model.sourcestamps
+
+        def __getSourcestampInfo(conn):
+            res = conn.execute(
+                sa.select([
+                    ss_tbl.c.branch,
+                    ss_tbl.c.revision,
+                    ss_tbl.c.repository,
+                    ss_tbl.c.codebase,
+                ]).where(ss_tbl.c.sourcestampsetid == sourcestampsetid))
+
+            row = res.fetchone()
+            return row.codebase, row.branch, row.revision
+
+        return self.master.db.pool.do(__getSourcestampInfo)
+
+    def _getMergeBrid(self, builder, builderName, priority, codebase, branch,
+                      revision, properties):
+        """
+        :param Builder builder:
+        :param str builderName:
+        :param str codebase:
+        :param int priority:
+        :param str branch:
+        :param str revision:
+        :param dict(str,str) properties:
+
+        :return str or None:
+            Build request id for a request that can be merged into (matches
+            buiderName, properties and sourcestamp information).
+
+            `None` if no match was found.
+        """
+        if 'selected_slave' in properties:
+            return None
+
+        # Get an initial list of all breqs that match the given source stamp data
+        matchingBrids = self._getBuildRequestIdsMatchingSourceStamp(
+            builderName, priority, codebase, branch, revision)
+
+        # Check if relevant properties match
+        for otherBuildsetid, otherBrid in matchingBrids:
+            otherProperties = self.properties_cache.get(otherBuildsetid)
+            if self._propertiesMatch(properties, otherProperties,
+                                     builder.config.mergeProperties):
+                return otherBrid
+        return None
+
+    def _getBuildRequestIdsMatchingSourceStamp(self, builderName, priority,
+                                               codebase, branch, revision):
+        """
+        :param str builderName:
+        :param int priority:
+        :param str codebase:
+        :param str branch:
+        :param str revision:
+        :return tuple(str,str):
+            (buildsetid, brid) for all buildrequests that match the given
+            builderName, priority and sourceStamp information.
+
+            Note that builds started without a revision (only a branch) might
+            not be able to merge to previous builds that were also started
+            without a revision but have already started and found the latest
+            revision in that branch. This happens because in this case we will
+            be searching for other buildRequests that have `revision==None`,
+            and running builds at some point update their properties to a real
+            revision.
+        """
+        bs_tbl = self.master.db.model.buildsets
+        breq_tbl = self.master.db.model.buildrequests
+        ss_tbl = self.master.db.model.sourcestamps
+
+        def __getBuildRequestIdsMatchingSourcestamp(conn):
+            # Select buildrequests
+            # q = sa.select(breq_tbl.c.buildsetid, breq_tbl.c.id) \
+
+            # That are not complete
+            #     .where(breq_tbl.c.complete == 0) \
+
+            # For this same builder
+            #     .where(breq_tbl.c.buildername == builderName) \
+
+            # That were not merged themselves (only merge against one / main target)
+            #     .where(breq_tbl.c.mergebrid == None) \
+
+            # And has the same priority (we could be smarter here, but it would make the query
+            # more complicated and possibly invert the merge target)
+            #     .where(breq_tbl.c.priority == priority) \
+
+            # Join on same sourcestamp (codebase, branch, revision)
+            #     .join(bs_tbl, bs_tbl.c.id == breq_tbl.c.buildsetid) \
+            #     .join(ss_tbl, ss_tbl.c.sourcestampsetid == bs_tbl.c.sourcestampsetid) \
+            #     .where(
+            #         ss_tbl.c.codebase == codebase,
+            #         ss_tbl.c.branch == branch,
+            #         ss_tbl.c.revision == revision,
+            #     )
+            q = sa.select(breq_tbl.c.buildsetid, breq_tbl.c.id) \
+                .where(breq_tbl.c.complete == 0) \
+                .where(breq_tbl.c.buildername == builderName) \
+                .where(breq_tbl.c.mergebrid == None) \
+                .where(breq_tbl.c.priority == priority) \
+                .join(bs_tbl, bs_tbl.c.id == breq_tbl.c.buildsetid) \
+                .join(ss_tbl, ss_tbl.c.sourcestampsetid == bs_tbl.c.sourcestampsetid) \
+                .where(
+                    ss_tbl.c.codebase == codebase,
+                    ss_tbl.c.branch == branch,
+                    ss_tbl.c.revision == revision,
+                )
+            res = conn.execute(q)
+            return res.fetchall() or []
+
+        return self.master.db.pool.do(__getBuildRequestIdsMatchingSourcestamp)
+
+    def _propertiesMatch(self, properties, otherProperties, mergeProperties):
+        """
+        :param dict(str,str) properties:
+        :param dict(str,str) otherProperties:
+        :param list(str) mergeProperties:
+            List of properties that must match
+        :return bool:
+            True if `properties` and `otherProperties` match for a list of
+            `mergeProperties` to be checked
+        """
+        if 'selected_slave' in otherProperties:
+            return False
+
+        for propertyName in self.BASE_MERGE_PROPERTIES + mergeProperties:
+            if properties.get(propertyName, None) != otherProperties.get(
+                    propertyName, None):
+                return False
+
+        return True
+
+    def __propertiesCacheMissFn(self, buildsetid):
+        """
+        :param str buildsetid:
+        :return dict(str,str):
+            Dictionary of properties for the given `buildsetid`
+        """
+        prop_tbl = self.master.db.model.buildset_properties
+
+        def __getBuildRequestProperties(conn):
+            q = sa.select(prop_tbl.c.property_name, prop_tbl.c.property_value) \
+                .where(prop_tbl.c.buildsetid == buildsetid)
+            res = conn.execute(q)
+
+            # Return properties as a dictionary
+            return {k: v for (k, v) in (res.fetchall() or [])}
+
+        return self.master.db.pool.do(__getBuildRequestProperties)

--- a/master/buildbot/process/buildrequestmerger.py
+++ b/master/buildbot/process/buildrequestmerger.py
@@ -43,8 +43,9 @@ class BuildRequestMerger(config.ReconfigurableServiceMixin, service.Service):
         ..seealso:: buildsets.addBuildset
             For parameter details
         """
-        start = time.time()
+        builderNames = sorted(builderNames)
 
+        start = time.time()
         buildsetLog = {
             'name': 'addBuildset',
             'description':

--- a/master/buildbot/test/unit/test_master.py
+++ b/master/buildbot/test/unit/test_master.py
@@ -183,7 +183,8 @@ class Subscriptions(dirs.DirsMixin, unittest.TestCase):
                
     def test_buildset_subscription(self):
         self.master.db = mock.Mock()
-        self.master.db.buildsets.addBuildset.return_value = \
+        self.master.buildrequest_merger = mock.Mock()
+        self.master.buildrequest_merger.addBuildset.return_value = \
             defer.succeed((938593, dict(a=19,b=20)))
 
         cb = mock.Mock()
@@ -191,9 +192,12 @@ class Subscriptions(dirs.DirsMixin, unittest.TestCase):
         self.assertIsInstance(sub, subscription.Subscription)
 
         d = self.master.addBuildset(ssid=999)
+
         def check((bsid,brids)):
             # master called the right thing in the db component
-            self.master.db.buildsets.addBuildset.assert_called_with(ssid=999)
+            self.master.buildrequest_merger.addBuildset.assert_called_with(
+                ssid=999
+            )
             # addBuildset returned the right value
             self.assertEqual((bsid,brids), (938593, dict(a=19,b=20)))
             # and the notification sub was called correctly

--- a/master/buildbot/util/lru.py
+++ b/master/buildbot/util/lru.py
@@ -209,14 +209,7 @@ class AsyncLRUCache(LRUCache):
 
         def handle_result(result):
             if result is not None:
-                self.cache[key] = result
-                self.weakrefs[key] = result
-
-                # reference the key once, possibly standing in for multiple
-                # concurrent accesses
-                self._ref_key(key)
-
-                self._purge()
+                self.put_new(key, result)
 
             # and fire all of the waiting Deferreds
             dlist = concurrent.pop(key)

--- a/master/buildbot/util/lru.py
+++ b/master/buildbot/util/lru.py
@@ -50,6 +50,12 @@ class LRUCache(object):
         elif key in self.weakrefs:
             self.weakrefs[key] = value
 
+    def put_new(self, key, value):
+        self.cache[key] = value
+        self.weakrefs[key] = value
+        self._ref_key(key)
+        self._purge()
+
     def get(self, key, **miss_fn_kwargs):
         try:
             return self._get_hit(key)
@@ -60,10 +66,7 @@ class LRUCache(object):
 
         result = self.miss_fn(key, **miss_fn_kwargs)
         if result is not None:
-            self.cache[key] = result
-            self.weakrefs[key] = result
-            self._ref_key(key)
-            self._purge()
+            self.put_new(key, result)
 
         return result
 


### PR DESCRIPTION
This will also require some changes to Katana configs, since now we are using a list of `merge_properties` to check, instead of python merge functions.

The plan is to test this in katana staging and keep an eye on logs to see if this "merge-on-add" covers all of our current cases.