### PR TITLE
CDS-641 Add mybuilds page

### DIFF
--- a/master/buildbot/status/web/baseweb.py
+++ b/master/buildbot/status/web/baseweb.py
@@ -30,6 +30,7 @@ from buildbot.status.web.base import StaticFile, createJinjaEnv
 from buildbot.status.web.feeds import Rss20StatusResource, \
      Atom10StatusResource
 from buildbot.status.web.forms import FormsKatanaResource
+from buildbot.status.web.mybuilds import MybuildsResource
 from buildbot.status.web.pngstatus import PngStatusResource
 from buildbot.status.web.waterfall import WaterfallStatusResource
 from buildbot.status.web.console import ConsoleStatusResource
@@ -435,7 +436,7 @@ class WebStatus(service.MultiService):
         self.putChild("logout", LogoutKatanaResource())
         self.putChild("login", LoginKatanaResource())
         self.putChild("forms", FormsKatanaResource())
-
+        self.putChild("mybuilds", MybuildsResource())
 
     def __repr__(self):
         if self.http_port is None:

--- a/master/buildbot/status/web/mybuilds.py
+++ b/master/buildbot/status/web/mybuilds.py
@@ -1,0 +1,18 @@
+from twisted.internet import defer
+
+from buildbot.status.web.base import HtmlResource
+
+
+class MybuildsResource(HtmlResource):
+    pageTitle = "MyBuilds"
+
+    @defer.inlineCallbacks
+    def content(self, req, cxt):
+        master = self.getBuildmaster(req)
+        username = cxt['authz'].getUsernameFull(req)
+        builds = yield master.db.builds.getLastBuildsOwnedBy(username, master.status.botmaster)
+
+        cxt['builds'] = builds
+        template = req.site.buildbot_service.templates.get_template("mybuilds.html")
+        template.autoescape = True
+        defer.returnValue(template.render(**cxt))

--- a/master/buildbot/test/fake/botmaster.py
+++ b/master/buildbot/test/fake/botmaster.py
@@ -15,6 +15,7 @@
 
 from twisted.application import service
 
+
 class FakeBotMaster(service.MultiService):
     def __init__(self, master):
         service.MultiService.__init__(self)
@@ -44,3 +45,11 @@ class FakeBotMaster(service.MultiService):
 
     def maybeStartBuildsForSlave(self, slavename):
         self.buildsStartedForSlaves.append(slavename)
+
+    def getBuilderConfig(self, name):
+        return FakeProject(name=name)
+
+
+class FakeProject:
+    def __init__(self, name):
+        self.project = 'project_' + name

--- a/www/templates/layout.html
+++ b/www/templates/layout.html
@@ -131,6 +131,9 @@
             <a id="projects" href="{{ path_to_root }}projects">Projects</a>            
             <span id="projectDropdown" class="arrow-down-btn"></span>            
           </li>
+            <li>
+               <a id="mybuilds" href="{{ path_to_root }}mybuilds">My builds</a>
+            </li>
           <li>
             <a id="buildslaves"  href="{{ path_to_root }}buildslaves">
               <span id="verticalProgressBar" class="outer-bar tooltip responsive-tooltip">

--- a/www/templates/mybuilds.html
+++ b/www/templates/mybuilds.html
@@ -1,0 +1,66 @@
+{% extends "layout.html" %}
+{% import 'submenu.html' as submenu %}
+
+{% set bodyId = 'id="mybuilds"' %}
+
+{% block content %}
+
+<h2>Your builds run in last 24h</h2>
+
+<table class="table table-katana table-stripes no-bg tablesorter dataTable tablesorter-js shortcut-js tools-js">
+    <thead>
+    <tr>
+        <th>Build ID</th>
+        <th>Project</th>
+        <th>Builder name</th>
+        <th>Completed</th>
+        <th>Build number</th>
+        <th>Build slave</th>
+        <th>Submitted at</th>
+        <th>Completed at</th>
+        <th>Reason</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for build in builds %}
+    <tr>
+        <td>
+            <a href="/projects/{{ build.project }}/builders/{{ build.buildername }}/builds/{{ build.builds_number }}">
+                {{ build.builds_id }}
+            </a>
+        </td>
+        <td>
+            {{ build.project }}
+        </td>
+        <td>
+            {{ build.buildername }}
+        </td>
+        <td
+                {% if build.complete %}
+                class="success"
+                {% else %}
+                class="failure"
+                {% endif %}
+        >
+            {{ build.complete }}
+        </td>
+        <td>
+            {{ build.builds_number }}
+        </td>
+        <td>
+            <a href="/buildslaves/{{ build.slavename }}">{{ build.slavename }}</a>
+        </td>
+        <td>
+            {{ build.submitted_at }}
+        </td>
+        <td>
+            {{ build.complete_at }}
+        </td>
+        <td>
+            {{ build.reason }}
+        </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
Navigating Katana can be difficult at times. One way to alleviate this is giving users the option to navigate to their own currently running builds. Another possible feature is to have builds run within a certain timeframe (e.g. last 24 hours).

Todo list:
- [x] for each buildername fetch project it belongs to
- [x] add link to build
- [x] limit results to most recent changes
- [x] move getBuildrequestsOwnedBy to builds instead buildrequests 
- [x] tests  
- [x] add some description what happen there(mads comment on ticket)
- [x] problem with chained builds
- [x] configurable last 15 up to 200 builds
- [x] correct tests with new query and data 
