### PR TITLE
CDS-1639 Return build number from a given build request ID

### DIFF
--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -1197,8 +1197,8 @@ class BuildRequestJsonResource(JsonResource):
 
         if request.postpath and request.postpath[0] == 'build_number':
             return BuildNumberForRequestJsonResource(self.status, build_request_id)
-        else:
-            return resource.NoResource('Resource not found.')
+
+        return resource.NoResource('Resource not found.')
 
 
 class BuildNumberForRequestJsonResource(JsonResource):


### PR DESCRIPTION
Added new API endpoint which returns build number from a given buildrequest, example:
```
REQUEST:
GET /json/build_request/{build_request_id}/build_number/

RESPONSE:
3
```
  