### PR TITLE
Custom URLs encoding fix

### DIFF
--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -20,6 +20,7 @@ import os
 import re
 import sys
 import warnings
+import urllib
 from buildbot.util import safeTranslate
 from buildbot import interfaces
 from buildbot import locks

--- a/master/buildbot/config.py
+++ b/master/buildbot/config.py
@@ -856,7 +856,7 @@ class BuilderConfig:
                 'name': key,
                 'url': value.format(
                         buildbotUrl=buildbotUrl,
-                        builderName=self.name,
+                        builderName=urllib.quote(self.name),
                         buildNumber=buildNumber,
                         buildUrl=buildUrl)
             })

--- a/master/buildbot/test/unit/test_config.py
+++ b/master/buildbot/test/unit/test_config.py
@@ -1238,6 +1238,33 @@ class BuilderConfig(ConfigErrorsMixin, unittest.TestCase):
             self.assertTrue(link['name'] in customBuildUrls)
             self.assertEquals(expectedLinks[link['name']], link['url'])
 
+    def test_customBuildUrlsWithSpecialCharacters(self):
+        customBuildUrls={
+            'Open My Tests Tool':
+                "http://tool.com/Build/View?katanaUrl={buildbotUrl}"
+                "&builderName={builderName}&buildNumber={buildNumber}&buildUrl={buildUrl}",
+            'name': 'url2'
+        }
+
+        cfg = config.BuilderConfig(
+                name='builder + il2cpp',
+                slavename='s1',
+                project="project",
+                factory=self.factory,
+                customBuildUrls=customBuildUrls
+        )
+
+        expectedLinks = {
+            'Open My Tests Tool': 'http://tool.com/Build/View?katanaUrl=test&builderName=builder%20%2B%20il2cpp&buildNumber=1'
+                                  '&buildUrl=http://buildbot.com/build/1',
+            'name': 'url2'
+        }
+
+        for link in cfg.getCustomBuildUrls(buildbotUrl="test", buildNumber=1, buildUrl="http://buildbot.com/build/1"):
+            self.assertTrue('name' in link and 'url' in link)
+            self.assertTrue(link['name'] in customBuildUrls)
+            self.assertEquals(expectedLinks[link['name']], link['url'])
+
     def test_customBuildUrlsFails(self):
         customBuildUrls={
             'Open My Tests Tool': "http://tool.com/Build/View?builderName={builderName}&buildNumber={buildNumber}",


### PR DESCRIPTION
Custom URLs shown on the builder screen (e.g. 'Show instabilities for this builder' and 'Investigate this builder in Hoarder') don't have their parameters encoded. In particular, some names of the builders contain special characters like '+' (e.g. 'proj0-Test RegressionRuntimeTests - Windows64Standalone (il2cpp + .NET2.0 profile))' and the 'plus' is being treated as a whitespace (%20) whereas it should be encoded as '%2B'. As a result the URL contains a non-existing builder parameter.

The fix was to use the urllib library to encode 'builderName'.

Does it make sense?