### PR TITLE
Trigger a new build API entry point

### DIFF
--- a/master/buildbot/schedulers/manager.py
+++ b/master/buildbot/schedulers/manager.py
@@ -39,8 +39,6 @@ class SchedulerManager(config.ReconfigurableServiceMixin,
                     return scheduler
                 elif isinstance(scheduler, scheduler_type):
                     return scheduler
-                else:
-                    continue
 
     @defer.inlineCallbacks
     def reconfigService(self, new_config):

--- a/master/buildbot/schedulers/manager.py
+++ b/master/buildbot/schedulers/manager.py
@@ -19,12 +19,28 @@ from twisted.python import log, reflect
 from buildbot.process import metrics
 from buildbot import config, util
 
+
 class SchedulerManager(config.ReconfigurableServiceMixin,
                        service.MultiService):
     def __init__(self, master):
         service.MultiService.__init__(self)
         self.setName('scheduler_manager')
         self.master = master
+
+    def findSchedulerByName(self, name):
+        for scheduler in self.services:
+            if name == scheduler.name:
+                return scheduler
+
+    def findSchedulerByBuilderName(self, builder_name, scheduler_type=None):
+        for scheduler in self.services:
+            if builder_name in scheduler.builderNames:
+                if scheduler_type is None:
+                    return scheduler
+                elif isinstance(scheduler, scheduler_type):
+                    return scheduler
+                else:
+                    continue
 
     @defer.inlineCallbacks
     def reconfigService(self, new_config):

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -34,48 +34,40 @@ from buildbot.status.web.build import BuildsResource, StatusResourceBuild
 from buildbot import util
 import collections
 
+
 class ForceAction(ActionResource):
+
     @defer.inlineCallbacks
     def force(self, req, builderNames):
         master = self.getBuildmaster(req)
         owner = self.getAuthz(req).getUsernameFull(req)
-        schedulername = req.args.get("forcescheduler", ["<unknown>"])[0]
-        if schedulername == "<unknown>":
-            try:
-                for scheduler in master.allSchedulers():
-                    if isinstance(scheduler, ForceScheduler) and builderNames[0] in scheduler.builderNames:
-                        schedulername = scheduler.name
-                        break
-                else:
-                    raise RuntimeError("Could not find force scheduler")
-            except:
-                defer.returnValue((path_to_builder(req, self.builder_status),
-                                   "forcescheduler arg not found, and could not find a default force scheduler for builderName"))
-                return
+        scheduler_name = req.args.get("forcescheduler", ["<unknown>"])[0]
 
-        args = {}
-        # decode all of the args
-        encoding = getRequestCharset(req)
-        for name, argl in req.args.iteritems():
-           if name == "checkbox":
-               # damn html's ungeneric checkbox implementation...
-               for cb in argl:
-                   args[cb.decode(encoding)] = True
-           else:
-               args[name] = [ arg.decode(encoding) for arg in argl ]
+        args = self.decode_request_arguments(req)
 
-        for scheduler in master.allSchedulers():
-            if schedulername == scheduler.name:
-                try:
-                    yield scheduler.force(owner, builderNames, **args)
-                    msg = ""
-                except ValidationError, e:
-                    msg = html.escape(e.message.encode('ascii','ignore'))
-                break
+        if scheduler_name == "<unknown>":
+            scheduler = master.scheduler_manager.findSchedulerByBuilderName(
+                builderNames[0], scheduler_type=ForceScheduler,
+            )
+        else:
+            scheduler = master.scheduler_manager.findSchedulerByName(name=scheduler_name)
+
+        try:
+            yield scheduler.force(owner, builderNames, **args)
+        except ValidationError:
+            pass
+        except AttributeError:
+            if scheduler_name == '<unknown>':
+                defer.returnValue(
+                    (
+                        path_to_builder(req, self.builder_status),
+                        'forcescheduler arg not found, and could not find a default force scheduler for builderName',
+                    ),
+                )
 
         # send the user back to the proper page
         returnpage = args.get("returnpage", {})
-        if  "builders" in returnpage:
+        if "builders" in returnpage:
             defer.returnValue((path_to_builders(req, self.builder_status.getProject())))
         elif "builders_json" in returnpage:
             s = self.getStatus(req)
@@ -84,6 +76,20 @@ class ForceAction(ActionResource):
             s = self.getStatus(req)
             defer.returnValue((s.getBuildbotURL() + path_to_json_pending(req, builderNames[0])))
         defer.returnValue((path_to_builder(req, self.builder_status)))
+
+    @staticmethod
+    def decode_request_arguments(request):
+        args = {}
+        encoding = getRequestCharset(request)
+
+        for name, argl in request.args.iteritems():
+            if name == 'checkbox':
+                for cb in argl:
+                    args[cb.decode(encoding)] = True
+            else:
+                args[name] = [arg.decode(encoding) for arg in argl]
+
+        return args
 
 
 class ForceAllBuildsActionResource(ForceAction):

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -74,7 +74,7 @@ class ForceAction(ActionResource):
                 break
 
         # send the user back to the proper page
-        returnpage = args.get("returnpage", None)
+        returnpage = args.get("returnpage", {})
         if  "builders" in returnpage:
             defer.returnValue((path_to_builders(req, self.builder_status.getProject())))
         elif "builders_json" in returnpage:

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -165,8 +165,7 @@ if 'allCompatible' was used then the list will contain build request object for 
 
     - Example:
     
-    - [{"build_request_id": 1}] 
->>>>>>> 105619308... added documentation for endpoint
+    - [{"build_request_id": 1}]
 """
 
 

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -129,6 +129,44 @@ EXAMPLES = """\
     - Global information about the current builds and slaves in use
   - /json/build_request/<BUILD_REQUEST_ID>/build_number/
     - A build number for a build request id.
+  - /json/builders/<A_BUILDER>/start-build/
+    - Start a new build. This endpoint accepts only POST method with the JSON payload.
+    
+    - Example payload:
+    
+    - {
+    
+    -    "force_chain_rebuild": true,
+    
+    -    "force_rebuild": true,
+    
+    -    "owner": pyflakes pyflakes <pyflakes@example.com>, 
+    # (Field required)
+    -    "priority": "50",
+    
+    -    "scheduler_name": "scheduler [force]", 
+    # (if not provided then the first force scheduler for given builder will be chosen)
+    -    "selected_slave": "slave_name",
+    # ('allCompatible' means that build will run on all slaves)
+    -    "sources_stamps": [{
+    
+    -        "branch": "test-branch",
+    
+    -        "repository": "test-repository",
+    
+    -        "revision": "5abcde"
+    
+    -    }]
+    
+    - }
+
+    - This endpoint will return the one element list of build request objects,
+if 'allCompatible' was used then the list will contain build request object for all slaves.
+
+    - Example:
+    
+    - [{"build_request_id": 1}] 
+>>>>>>> 105619308... added documentation for endpoint
 """
 
 

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -17,7 +17,6 @@
 """Simple JSON exporter."""
 
 import datetime
-import itertools
 import json
 import re
 import time
@@ -136,15 +135,9 @@ EXAMPLES = """\
     - Example payload:
     
     - {
-    
-    -    "force_chain_rebuild": true,
-    
-    -    "force_rebuild": true,
-    
+
     -    "owner": pyflakes pyflakes <pyflakes@example.com>, 
     # (Field required)
-    -    "priority": "50",
-    
     -    "scheduler_name": "scheduler [force]", 
     # (if not provided then the first force scheduler for given builder will be chosen)
     -    "selected_slave": "slave_name",
@@ -157,7 +150,17 @@ EXAMPLES = """\
     
     -        "revision": "5abcde"
     
-    -    }]
+    -    }],
+    
+    -   "build_properties": {
+    
+    -       "force_chain_rebuild": true,
+    
+    -       "force_rebuild": true,
+
+    -       "priority": "50",
+    
+    -       "reason": "description"
     
     - }
 
@@ -166,7 +169,7 @@ if 'allCompatible' was used then the list will contain build request object for 
 
     - Example:
     
-    - [{"build_request_id": 1}]
+    - [{"build_request_id": 1}] or with 'allCompatible' [{"build_request_id": 1}, {"build_request_id": 2}]
 """
 
 

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -483,6 +483,7 @@ class StartBuildJsonResource(AccessorMixin, resource.Resource):
                 },
             },
         },
+        'additionalProperties': False,
         'required': ['owner'],
     }
 
@@ -511,6 +512,7 @@ class StartBuildJsonResource(AccessorMixin, resource.Resource):
 
     @defer.inlineCallbacks
     def _deferred_render(self, request):
+        master = self.getBuildmaster(request)
         request_data = json.load(request.content)
 
         try:
@@ -518,8 +520,6 @@ class StartBuildJsonResource(AccessorMixin, resource.Resource):
         except jsonschema.exceptions.ValidationError as exc:
             request.setResponseCode(400)
             defer.returnValue({'error': exc.message})
-
-        master = self.getBuildmaster(request)
 
         if 'scheduler_name' in request_data:
             scheduler = master.scheduler_manager.findSchedulerByName(request_data['scheduler_name'])
@@ -557,8 +557,8 @@ class StartBuildJsonResource(AccessorMixin, resource.Resource):
             revision = source_stamp['revision']
             branch = source_stamp['branch']
 
-            converted_sources_stamps['{}_{}'.format(repository, revision)] = revision
-            converted_sources_stamps['{}_{}'.format(repository, branch)] = branch
+            converted_sources_stamps['{}_revision'.format(repository)] = revision
+            converted_sources_stamps['{}_branch'.format(repository)] = branch
 
         return converted_sources_stamps
 

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -190,28 +190,23 @@ class SchedulerManager(unittest.TestCase):
     def test_finding_scheduler_by_builder_name(self):
         scheduler_manager = manager.SchedulerManager(self.master)
 
-        first_scheduler = mock.Mock(spec=self.Sched)
-        first_scheduler.builderNames = ['builder_a', 'builder_b']
+        first_scheduler = mock.Mock(spec=self.Sched, builderNames=['builder_a', 'builder_b'])
         scheduler_manager.addService(first_scheduler)
 
-        second_scheduler = mock.Mock(spec=self.Sched)
-        second_scheduler.builderNames = ['builder_c', 'builder_d']
+        second_scheduler = mock.Mock(spec=self.Sched, builderNames=['builder_c', 'builder_d'])
         scheduler_manager.addService(second_scheduler)
 
         self.assertEqual(scheduler_manager.findSchedulerByBuilderName('builder_c'), second_scheduler)
 
     def test_finding_scheduler_by_builder_name_filter_by_scheduler_type(self):
-        class Sched2(base.BaseScheduler):
-            pass
+        fake_scheduler_type = type('FakeScheduler', (base.BaseScheduler, ), {})
 
         scheduler_manager = manager.SchedulerManager(self.master)
 
-        first_scheduler = mock.Mock(spec=self.Sched)
-        first_scheduler.builderNames = ['builder_a', 'builder_b']
+        first_scheduler = mock.Mock(spec=self.Sched, builderNames=['builder_a', 'builder_b'])
         scheduler_manager.addService(first_scheduler)
 
-        second_scheduler = mock.Mock(spec=Sched2)
-        second_scheduler.builderNames = ['builder_b', 'builder_c']
+        second_scheduler = mock.Mock(spec=fake_scheduler_type, builderNames=['builder_b', 'builder_c'])
         scheduler_manager.addService(second_scheduler)
 
         self.assertEqual(
@@ -220,6 +215,6 @@ class SchedulerManager(unittest.TestCase):
         )
 
         self.assertEqual(
-            scheduler_manager.findSchedulerByBuilderName('builder_b', scheduler_type=Sched2),
+            scheduler_manager.findSchedulerByBuilderName('builder_b', scheduler_type=fake_scheduler_type),
             second_scheduler,
         )

--- a/master/buildbot/test/unit/test_schedulers_manager.py
+++ b/master/buildbot/test/unit/test_schedulers_manager.py
@@ -19,6 +19,7 @@ from twisted.internet import defer
 from buildbot.schedulers import manager, base
 from buildbot import config
 
+
 class SchedulerManager(unittest.TestCase):
 
     def setUp(self):
@@ -166,3 +167,59 @@ class SchedulerManager(unittest.TestCase):
         self.assertIdentical(sch1_new.master, self.master)
         self.assertIdentical(sch2.parent, self.sm)
         self.assertIdentical(sch2.master, self.master)
+
+    def test_finding_scheduler_by_name(self):
+        scheduler_manager = manager.SchedulerManager(self.master)
+
+        mocked_schedulers = [
+            mock.Mock(spec=self.Sched),
+            mock.Mock(spec=self.Sched),
+            mock.Mock(spec=self.ReconfigSched),
+            mock.Mock(spec=self.ReconfigSched),
+        ]
+
+        for index, scheduler in enumerate(mocked_schedulers):
+            scheduler.name = 'scheduler-{}'.format(index)
+            scheduler_manager.addService(scheduler)
+
+        for scheduler in mocked_schedulers:
+            self.assertEqual(scheduler_manager.findSchedulerByName(scheduler.name), scheduler)
+
+        self.assertIsNone(scheduler_manager.findSchedulerByName('not-existing-scheduler'))
+
+    def test_finding_scheduler_by_builder_name(self):
+        scheduler_manager = manager.SchedulerManager(self.master)
+
+        first_scheduler = mock.Mock(spec=self.Sched)
+        first_scheduler.builderNames = ['builder_a', 'builder_b']
+        scheduler_manager.addService(first_scheduler)
+
+        second_scheduler = mock.Mock(spec=self.Sched)
+        second_scheduler.builderNames = ['builder_c', 'builder_d']
+        scheduler_manager.addService(second_scheduler)
+
+        self.assertEqual(scheduler_manager.findSchedulerByBuilderName('builder_c'), second_scheduler)
+
+    def test_finding_scheduler_by_builder_name_filter_by_scheduler_type(self):
+        class Sched2(base.BaseScheduler):
+            pass
+
+        scheduler_manager = manager.SchedulerManager(self.master)
+
+        first_scheduler = mock.Mock(spec=self.Sched)
+        first_scheduler.builderNames = ['builder_a', 'builder_b']
+        scheduler_manager.addService(first_scheduler)
+
+        second_scheduler = mock.Mock(spec=Sched2)
+        second_scheduler.builderNames = ['builder_b', 'builder_c']
+        scheduler_manager.addService(second_scheduler)
+
+        self.assertEqual(
+            scheduler_manager.findSchedulerByBuilderName('builder_b', scheduler_type=self.Sched),
+            first_scheduler,
+        )
+
+        self.assertEqual(
+            scheduler_manager.findSchedulerByBuilderName('builder_b', scheduler_type=Sched2),
+            second_scheduler,
+        )

--- a/master/buildbot/test/unit/test_status_web_force_action.py
+++ b/master/buildbot/test/unit/test_status_web_force_action.py
@@ -1,0 +1,115 @@
+import mock
+
+from twisted.internet import defer
+from twisted.web.test.requesthelper import DummyRequest
+from twisted.trial import unittest
+
+from buildbot.schedulers.base import BaseScheduler
+from buildbot.schedulers.forcesched import ForceScheduler
+from buildbot.status.web.builder import ForceAction
+from buildbot.test.fake.fakemaster import FakeBuilderStatus, FakeMaster
+
+
+class TestForceAction(unittest.TestCase):
+
+    def setUp(self):
+        self.builder_name = 'proj0-test-builder'
+        self.project = 'proj0'
+
+        self.builder_status = FakeBuilderStatus(
+            buildername=self.builder_name, project=self.project,
+        )
+        self.master = FakeMaster()
+        self.request = DummyRequest([])
+        self.request.site = mock.Mock(
+            buildbot_service=mock.Mock(master=self.master),
+        )
+
+        self.force_action_resource = ForceAction()
+        self.force_action_resource.builder_status = self.builder_status
+
+    @defer.inlineCallbacks
+    def test_forcescheduler_param(self):
+        first_scheduler = self._scheduler_factory(
+            spec=ForceScheduler, name='test-scheduler-0+[force]',
+        )
+        self.master.scheduler_manager.addService(first_scheduler)
+
+        selected_scheduler = self._scheduler_factory(
+            spec=ForceScheduler, name='test-scheduler-1+[force]',
+        )
+        self.master.scheduler_manager.addService(selected_scheduler)
+
+        self.request.addArg('forcescheduler', selected_scheduler.name)
+
+        yield self.force_action_resource.force(self.request, [self.builder_name])
+
+        selected_scheduler.force.assert_called_once()
+        first_scheduler.force.assert_not_called()
+
+    @staticmethod
+    def _scheduler_factory(spec, **kwargs):
+        scheduler = mock.Mock(spec=spec)
+
+        for attribute, value in kwargs.items():
+            setattr(scheduler, attribute, value)
+
+        return scheduler
+
+    @defer.inlineCallbacks
+    def test_forcescheduler_param_empty(self):
+        first_scheduler = self._scheduler_factory(
+            spec=ForceScheduler, name='test-scheduler-0+[force]', builderNames=[],
+        )
+        self.master.scheduler_manager.addService(first_scheduler)
+
+        selected_scheduler = self._scheduler_factory(
+            spec=ForceScheduler,
+            name='test-scheduler-1+[force]',
+            builderNames=[self.builder_name],
+        )
+        self.master.scheduler_manager.addService(selected_scheduler)
+
+        yield self.force_action_resource.force(self.request, [self.builder_name])
+
+        selected_scheduler.force.assert_called_once()
+        first_scheduler.force.assert_not_called()
+
+    @defer.inlineCallbacks
+    def test_forcescheduler_param_empty_only_force_schedulers_allowed(self):
+        first_scheduler = self._scheduler_factory(
+            spec=BaseScheduler,
+            name='test-scheduler-0+[force]',
+            builderNames=[self.builder_name],
+        )
+        self.master.scheduler_manager.addService(first_scheduler)
+
+        selected_scheduler = self._scheduler_factory(
+            spec=ForceScheduler,
+            name='test-scheduler-1+[force]',
+            builderNames=[self.builder_name],
+        )
+        self.master.scheduler_manager.addService(selected_scheduler)
+
+        yield self.force_action_resource.force(self.request, [self.builder_name])
+
+        selected_scheduler.force.assert_called_once()
+
+    @defer.inlineCallbacks
+    def test_forcescheduler_param_empty_scheduler_not_found(self):
+        scheduler = self._scheduler_factory(
+            spec=ForceScheduler,
+            name='test-scheduler-0+[force]',
+            builderNames=[],
+        )
+        self.master.scheduler_manager.addService(scheduler)
+
+        result = yield self.force_action_resource.force(self.request, [self.builder_name])
+
+        self.assertEqual(
+            result,
+            (
+                'projects/{}/builders/{}'.format(self.project, self.builder_name),
+                'forcescheduler arg not found, and could not find a default force scheduler for builderName',
+            ),
+        )

--- a/master/buildbot/test/unit/test_status_web_force_action.py
+++ b/master/buildbot/test/unit/test_status_web_force_action.py
@@ -29,15 +29,14 @@ class TestForceAction(unittest.TestCase):
         self.force_action_resource.builder_status = self.builder_status
 
     @defer.inlineCallbacks
-    def test_forcescheduler_param(self):
-        first_scheduler = self._scheduler_factory(
-            spec=ForceScheduler, name='test-scheduler-0+[force]',
-        )
-        self.master.scheduler_manager.addService(first_scheduler)
+    def test_forcescheduler_form_param(self):
+        first_scheduler = mock.Mock(spec=ForceScheduler)
+        first_scheduler.name = 'test-scheduler-0+[force]'
 
-        selected_scheduler = self._scheduler_factory(
-            spec=ForceScheduler, name='test-scheduler-1+[force]',
-        )
+        selected_scheduler = mock.Mock(spec=ForceScheduler)
+        selected_scheduler.name = 'test-scheduler-1+[force]'
+
+        self.master.scheduler_manager.addService(first_scheduler)
         self.master.scheduler_manager.addService(selected_scheduler)
 
         self.request.addArg('forcescheduler', selected_scheduler.name)
@@ -47,27 +46,15 @@ class TestForceAction(unittest.TestCase):
         selected_scheduler.force.assert_called_once()
         first_scheduler.force.assert_not_called()
 
-    @staticmethod
-    def _scheduler_factory(spec, **kwargs):
-        scheduler = mock.Mock(spec=spec)
-
-        for attribute, value in kwargs.items():
-            setattr(scheduler, attribute, value)
-
-        return scheduler
-
     @defer.inlineCallbacks
-    def test_forcescheduler_param_empty(self):
-        first_scheduler = self._scheduler_factory(
-            spec=ForceScheduler, name='test-scheduler-0+[force]', builderNames=[],
-        )
-        self.master.scheduler_manager.addService(first_scheduler)
+    def test_forcescheduler_form_param_empty(self):
+        first_scheduler = mock.Mock(spec=ForceScheduler, builderNames=[])
+        first_scheduler.name = 'test-scheduler-0+[force]'
 
-        selected_scheduler = self._scheduler_factory(
-            spec=ForceScheduler,
-            name='test-scheduler-1+[force]',
-            builderNames=[self.builder_name],
-        )
+        selected_scheduler = mock.Mock(spec=ForceScheduler, builderNames=[self.builder_name])
+        selected_scheduler.name = 'test-scheduler-1+[force]'
+
+        self.master.scheduler_manager.addService(first_scheduler)
         self.master.scheduler_manager.addService(selected_scheduler)
 
         yield self.force_action_resource.force(self.request, [self.builder_name])
@@ -76,19 +63,14 @@ class TestForceAction(unittest.TestCase):
         first_scheduler.force.assert_not_called()
 
     @defer.inlineCallbacks
-    def test_forcescheduler_param_empty_only_force_schedulers_allowed(self):
-        first_scheduler = self._scheduler_factory(
-            spec=BaseScheduler,
-            name='test-scheduler-0+[force]',
-            builderNames=[self.builder_name],
-        )
-        self.master.scheduler_manager.addService(first_scheduler)
+    def test_forcescheduler_form_param_empty_only_force_schedulers_allowed(self):
+        first_scheduler = mock.Mock(spec=BaseScheduler, builderNames=[self.builder_name])
+        first_scheduler.name = 'test-scheduler-0+[force]'
 
-        selected_scheduler = self._scheduler_factory(
-            spec=ForceScheduler,
-            name='test-scheduler-1+[force]',
-            builderNames=[self.builder_name],
-        )
+        selected_scheduler = mock.Mock(spec=ForceScheduler, builderNames=[self.builder_name])
+        selected_scheduler.name = 'test-scheduler-1+[force]'
+
+        self.master.scheduler_manager.addService(first_scheduler)
         self.master.scheduler_manager.addService(selected_scheduler)
 
         yield self.force_action_resource.force(self.request, [self.builder_name])
@@ -96,12 +78,10 @@ class TestForceAction(unittest.TestCase):
         selected_scheduler.force.assert_called_once()
 
     @defer.inlineCallbacks
-    def test_forcescheduler_param_empty_scheduler_not_found(self):
-        scheduler = self._scheduler_factory(
-            spec=ForceScheduler,
-            name='test-scheduler-0+[force]',
-            builderNames=[],
-        )
+    def test_forcescheduler_form_param_empty_scheduler_not_found(self):
+        scheduler = mock.Mock(spec=ForceScheduler, builderNames=[])
+        scheduler.name = 'test-scheduler-0+[force]'
+
         self.master.scheduler_manager.addService(scheduler)
 
         result = yield self.force_action_resource.force(self.request, [self.builder_name])
@@ -115,6 +95,8 @@ class TestForceAction(unittest.TestCase):
         )
 
     def test_decode_request_arguments(self):
-        self.request.addArg('checkbox', 'checkbox-selected')
+        self.request.args['checkbox'] = ['checkbox-selected-1', 'checkbox-selected-2']
+
         args = ForceAction.decode_request_arguments(self.request)
-        self.assertEqual(args, {'checkbox-selected': True})
+
+        self.assertEqual(args, {'checkbox-selected-1': True, 'checkbox-selected-2': True})

--- a/master/buildbot/test/unit/test_status_web_force_action.py
+++ b/master/buildbot/test/unit/test_status_web_force_action.py
@@ -113,3 +113,8 @@ class TestForceAction(unittest.TestCase):
                 'forcescheduler arg not found, and could not find a default force scheduler for builderName',
             ),
         )
+
+    def test_decode_request_arguments(self):
+        self.request.addArg('checkbox', 'checkbox-selected')
+        args = ForceAction.decode_request_arguments(self.request)
+        self.assertEqual(args, {'checkbox-selected': True})

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -18,14 +18,10 @@ from StringIO import StringIO
 
 import mock
 
-<<<<<<< HEAD
-from twisted.trial import unittest
-from twisted.web import resource
-=======
 from twisted.internet import defer
 from twisted.trial import unittest
+from twisted.web import resource
 from twisted.web.test.requesthelper import DummyRequest
->>>>>>> 2e6716581... added missing unit tests
 
 from buildbot.status.web import status_json
 from buildbot.config import ProjectConfig

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -996,7 +996,6 @@ class TestStartBuildJsonResource(unittest.TestCase):
         self.assertEqual(self.request.responseCode, 404)
         self.assertDictEqual(response, {'error': 'Scheduler not found'})
 
-
     @defer.inlineCallbacks
     def test_invalid_json_in_payload(self):
         invalid_json_param = '{"owner": "Test User <test.user@example.com>",}'

--- a/master/buildbot/test/unit/test_status_web_status_json.py
+++ b/master/buildbot/test/unit/test_status_web_status_json.py
@@ -798,15 +798,6 @@ class TestStartBuildJsonResource(unittest.TestCase):
             self.master.status, self.builder_status,
         )
 
-    @staticmethod
-    def _scheduler_factory(spec, **kwargs):
-        scheduler = mock.Mock(spec=spec)
-
-        for attribute, value in kwargs.items():
-            setattr(scheduler, attribute, value)
-
-        return scheduler
-
     def test_convert_sources_stamps(self):
         sources_stamps = [
             {
@@ -835,11 +826,11 @@ class TestStartBuildJsonResource(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_start_new_build_single_slave(self):
-        force_scheduler = self._scheduler_factory(
-            ForceScheduler,
-            name='force-scheduler-0 [force]',
+        force_scheduler = mock.Mock(
+            spec=ForceScheduler,
             force=mock.Mock(return_value=(1, {self.builder_status.name: 2})),
         )
+        force_scheduler.name = 'force-scheduler-0 [force]'
         self.master.scheduler_manager.addService(force_scheduler)
 
         build_params = {
@@ -873,14 +864,14 @@ class TestStartBuildJsonResource(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_start_new_build_multiple_slaves(self):
-        force_scheduler = self._scheduler_factory(
-            ForceScheduler,
-            name='force-scheduler-0 [force]',
+        force_scheduler = mock.Mock(
+            spec=ForceScheduler,
             force=mock.Mock(return_value=[
                 (1, {self.builder_status.name: 2}),
                 (2, {self.builder_status.name: 4}),
             ]),
         )
+        force_scheduler.name = 'force-scheduler-0 [force]'
         self.master.scheduler_manager.addService(force_scheduler)
 
         build_params = {
@@ -986,6 +977,8 @@ class TestStartBuildJsonResource(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_scheduler_not_found(self):
+        self.master.scheduler_manager.services = []
+
         build_params = {
             'force_chain_rebuild': True,
             'force_rebuild': True,

--- a/master/setup.py
+++ b/master/setup.py
@@ -201,6 +201,7 @@ else:
         'pynats == 0.0.1',
         'www',
         'psutil == 4.3.0',
+        'jsonschema == 2.6.0',
     ]
     setup_args['tests_require'] = [
         'mock == 1.3.0',


### PR DESCRIPTION
Trigger new build using HTTP endpoint. For example:
```
http://katana:8001/json/builders/proj55-ParentA_ChildA_GrandChildA/start-build/ 
```
EXAMPLE POST REQUEST (for more options please look at JSON help page):
``` json
{
	"force_chain_rebuild": true,
	"force_rebuild": true,
	"owner": "Kornel Maleszka <kornel.maleszka@stxnext.pl>",
	"selected_slave": "allCompatible"
}
```
RESPONSE:
```json
[
    {
        "build_request_id": 9
    },
    {
        "build_request_id": 8
    }
]
```

TO DO:
- [x] - handle multiple slaves
- [x] - unit tests
- [x] - documentation
- [x] - handle custom properties in api endpoint

  