### PR TITLE
Toolsmiths/fix default int property

### DIFF
--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -95,6 +95,8 @@ class BaseParameter(object, ComparableMixin):
         if len(args) == 0:
             if self.required:
                 raise ValidationError("'%s' needs to be specified" % (self.label))
+            if self.readonly:
+                return None
             if self.multiple:
                 args = self.default
             else:
@@ -121,7 +123,9 @@ class BaseParameter(object, ComparableMixin):
 
     def updateFromKwargs(self, properties, kwargs, **unused):
         """Primary entry point to turn 'kwargs' into 'properties'"""
-        properties[self.name] = self.getFromKwargs(kwargs)
+        value = self.getFromKwargs(kwargs)
+        if value is not None:
+            properties[self.name] = value
 
     def parse_from_args(self, l):
         """Secondary customization point, called from getFromKwargs to turn

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -95,8 +95,6 @@ class BaseParameter(object, ComparableMixin):
         if len(args) == 0:
             if self.required:
                 raise ValidationError("'%s' needs to be specified" % (self.label))
-            if self.readonly:
-                return None
             if self.multiple:
                 args = self.default
             else:
@@ -123,9 +121,9 @@ class BaseParameter(object, ComparableMixin):
 
     def updateFromKwargs(self, properties, kwargs, **unused):
         """Primary entry point to turn 'kwargs' into 'properties'"""
-        value = self.getFromKwargs(kwargs)
-        if value is not None:
-            properties[self.name] = value
+        if self.readonly and self.fullName not in kwargs:
+            return
+        properties[self.name] = self.getFromKwargs(kwargs)
 
     def parse_from_args(self, l):
         """Secondary customization point, called from getFromKwargs to turn

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -218,6 +218,8 @@ def buildForceContextForSingleFieldWithValue(default_props, scheduler, field, ma
         if choices and value not in choices:
             value = choices[0]
         default_props[pname+".choices"] = choices
+    elif "bool" in field.type:
+        value = value is True or value == 'True'
     elif isinstance(value, unicode):
         # filter out unicode chars, and html stuff
         value = html.escape(value.encode('utf-8','ignore'))

--- a/master/buildbot/status/web/status_json.py
+++ b/master/buildbot/status/web/status_json.py
@@ -1415,6 +1415,8 @@ For help on any sub directory, use url /child/help
             return
         EXAMPLES = EXAMPLES.replace('<A_BUILDER>', builder.getName())
         build = builder.getBuild(-1)
+        if not build:
+            return
         projects = self.status.getProjects().keys()
         if len(projects) > 0:
             EXAMPLES = EXAMPLES.replace('<A_PROJECT>', projects[0])

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -363,14 +363,22 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
 
     def test_BooleanParameter_True(self):
         req = dict(p1=True,reason='because')
-        self.do_ParameterTest(value="123", expect=True, klass=BooleanParameter,
-                req=req)
+        self.do_ParameterTest(expect=True, klass=BooleanParameter, req=req)
+
+
+    def test_WhenBooleanParameterIsStringTrue_ThenPropertyIsSetToTrue(self):
+        req = dict(p1='True',reason='because')
+        self.do_ParameterTest(expect=True, klass=BooleanParameter, req=req)
+
+
+    def test_WhenBooleanParameterIsRandomString_ThenPropertyIsSetToFalse(self):
+        req = dict(p1='Foobar',reason='because')
+        self.do_ParameterTest(expect=False, klass=BooleanParameter, req=req)
 
 
     def test_BooleanParameter_False(self):
         req = dict(p2=True,reason='because')
-        self.do_ParameterTest(value="123", expect=False,
-                klass=BooleanParameter, req=req)
+        self.do_ParameterTest(expect=False, klass=BooleanParameter, req=req)
 
 
     def test_UserNameParameter(self):

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -419,6 +419,18 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                 klass=ChoiceStringParameter, choices=['t1','t2'],
                 multiple=True, debug=False)
 
+    def test_WhenRequestDoesNotContainValueAndItIsReadonly_ThenPropertyIsNotAssigned(self):
+        self.do_ParameterTest(req=dict(reason='because'),
+                expect={},
+                expectKind=dict,
+                klass=IntParameter,
+                readonly=True)
+
+    def test_WhenRequestContainsValueAndPropertyIsReadonly_ThenPropertyIsAssignedWithValue(self):
+        self.do_ParameterTest(value=['42'],
+                expect=42,
+                klass=IntParameter,
+                readonly=True)
 
     def test_NestedParameter(self):
         fields = [


### PR DESCRIPTION
We don't want to try to set properties for readonly values don't exists in the force form

Also adds a workaround for corrupted local python pickle? - not sure if this is a good fix or not or some automatic clean up would have been better.