### PR TITLE
CDS-970: check if BuildStepStatus has step_type_obj

### DIFF
--- a/master/buildbot/status/buildstep.py
+++ b/master/buildbot/status/buildstep.py
@@ -377,6 +377,10 @@ class BuildStepStatus(styles.Versioned):
     @defer.inlineCallbacks
     def prepare_trigger_links(self):
         from buildbot.steps.trigger import Trigger
+
+        if not hasattr(self, 'step_type_obj'):
+            return
+
         if self.step_type_obj is not Trigger:
             return
 


### PR DESCRIPTION
Add case when BuildStepStatus does not have step_type_obj yet (instance read from file).