### PR TITLE
Fix tests with freezed time

### DIFF
--- a/master/setup.py
+++ b/master/setup.py
@@ -202,6 +202,7 @@ else:
         'www',
         'psutil == 4.3.0',
         'jsonschema == 2.6.0',
+        'freezegun == 0.3.9',
     ]
     setup_args['tests_require'] = [
         'mock == 1.3.0',


### PR DESCRIPTION
After a few days, some tests are failing. It was caused by wrong `datetime.now` mocking. 