### PR TITLE
CDSK-840 - use friendly_name for Dependency labels

### DIFF
--- a/master/buildbot/status/buildstep.py
+++ b/master/buildbot/status/buildstep.py
@@ -390,7 +390,9 @@ class BuildStepStatus(styles.Versioned):
                         .getBuildRequestForStartbrids(brids)
         master = self.build.builder.master
         for build in db_results:
-            url = master.status.getURLForBuild(build['buildername'], build['number'])
+            friendly_name = master.status.getFriendlyName(build['buildername'])
+            url = master.status.getURLForBuild(build['buildername'], build['number'],
+                                               friendly_name=friendly_name)
             results = (build['results'],)  # must be tuple
             self.addURL(url['text'], url['path'], results)
 

--- a/master/buildbot/status/master.py
+++ b/master/buildbot/status/master.py
@@ -319,6 +319,13 @@ class Status(config.ReconfigurableServiceMixin, service.MultiService):
 
         return None
 
+    def getFriendlyName(self, buildNumber):
+        _builder = self.getBuilder(buildNumber)
+        if _builder is not None:
+            return _builder.friendly_name
+        else:
+            return None
+
     def getSlaveNames(self):
         return self.botmaster.slaves.keys()
 

--- a/master/buildbot/steps/trigger.py
+++ b/master/buildbot/steps/trigger.py
@@ -215,7 +215,7 @@ class Trigger(ResumeBuild):
                     if was_cb:
                         for build in builddicts:
                             bn = triggeredBuildIdsToBuildNames[build['brid']]
-                            friendly_name = self._getFriendlyName(master, bn)
+                            friendly_name = master.status.getFriendlyName(bn)
                             num = build['number']
                             url = yield master.status.getURLForBuildRequest(build['brid'], bn, num,
                                                                             friendly_name, self.sourceStamps)
@@ -226,7 +226,7 @@ class Trigger(ResumeBuild):
                     if was_cb:
                         for build in builddicts:
                             bn = triggeredBuildIdsToBuildNames[build['brid']]
-                            friendly_name = self._getFriendlyName(master, bn)
+                            friendly_name = master.status.getFriendlyName(bn)
                             num = build['number']
                             url = master.status.getURLForBuild(bn, num, friendly_name, self.sourceStamps)
                             self.step_status.addURL(url['text'], url['path'], *getBuildResults(build))
@@ -241,15 +241,6 @@ class Trigger(ResumeBuild):
         log.msg("Trigger scheduler result %d " % result)
         self.finishIfRunning(result)
         return
-
-
-    def _getFriendlyName(self, master, buildNumber):
-        builder = master.getStatus().getBuilder(buildNumber)
-        if builder is not None:
-            return builder.friendly_name
-        else:
-            return None
-
 
     def _triggerSchedulers(self, triggered_schedulers):
         dl = []

--- a/master/buildbot/test/unit/test_status_buildstep.py
+++ b/master/buildbot/test/unit/test_status_buildstep.py
@@ -155,7 +155,8 @@ class TestBuildStepStatus(unittest.TestCase):
         trigger_step_status = build.addStepWithName('step_2', Trigger)
         build.builder.master.db = StubDB()
         build.brids = [1]
-        build.builder.master.status.getURLForBuild = lambda x,y: {'path':x, 'text': y}
+        build.builder.master.status.getURLForBuild = lambda x, y, friendly_name: {'path':x, 'text': y}
+        build.builder.master.status.getFriendlyName = lambda x: None
 
         self.assertEqual(len(trigger_step_status.urls), 0)
 
@@ -180,7 +181,8 @@ class TestBuildStepStatus(unittest.TestCase):
         trigger_step_status = build.addStepWithName('step_2', Trigger)
         build.builder.master.db = StubDB()
         build.brids = [1]
-        build.builder.master.status.getURLForBuild = lambda x,y: {'path':x, 'text': y}
+        build.builder.master.status.getFriendlyName = lambda x: None
+        build.builder.master.status.getURLForBuild = lambda x, y, friendly_name: {'path':x, 'text': y}
 
         self.assertEqual(len(trigger_step_status.urls), 0)
 


### PR DESCRIPTION
Use friendly name for Dependencies in progress (BuildStepStatus.prepare_trigger_links).

For this purpose move method Trigger._getFriendlyName to Status.getFriendlyName