### PR TITLE
CDSK-920 - use user_id from request via ForceScheduler for build_user

### DIFF
--- a/master/buildbot/process/build.py
+++ b/master/buildbot/process/build.py
@@ -434,8 +434,11 @@ class Build(properties.PropertiesMixin):
         # gather owners from build requests
         owners = [r.properties['owner'] for r in self.requests
                   if r.properties.has_key('owner')]
+        user_ids = [r.properties['user_id'] for r in self.requests
+                    if r.properties.has_key('user_id')]
         if owners: self.setProperty('owners', owners, self.reason)
         self.build_status.setOwners(owners)
+        if user_ids: self.build_status.setUserID(user_ids[0])
 
         self.results = [] # list of FAILURE, SUCCESS, WARNINGS, SKIPPED
         self.result = SUCCESS # overall result, may downgrade after each step

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -776,6 +776,7 @@ class BuilderControl:
         """
         TODO: This method is probably is not used. Consider to remove it.
         """
+        klog.err_json("rebuildBuild_still_works. Don't remove me")
         if not bs.isFinished():
             return
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -773,6 +773,9 @@ class BuilderControl:
 
     @defer.inlineCallbacks
     def rebuildBuild(self, bs, reason="<rebuild, no reason given>", extraProperties=None, absolute=True, newOwner=''):
+        """
+        TODO: This method is probably is not used. Consider to remove it.
+        """
         if not bs.isFinished():
             return
 

--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -774,7 +774,7 @@ class BuilderControl:
     @defer.inlineCallbacks
     def rebuildBuild(self, bs, reason="<rebuild, no reason given>", extraProperties=None, absolute=True, newOwner=''):
         """
-        TODO: This method is probably is not used. Consider to remove it.
+        TODO: This method is not used probably. Consider to remove it.
         """
         klog.err_json("rebuildBuild_still_works. Don't remove me")
         if not bs.isFinished():

--- a/master/buildbot/schedulers/forcesched.py
+++ b/master/buildbot/schedulers/forcesched.py
@@ -654,11 +654,13 @@ class ForceScheduler(base.BaseScheduler):
         reason = self.reason.getFromKwargs(kwargs)
         if owner is None:
             owner = self.username.getFromKwargs(kwargs)
+        user_id = kwargs.get('user_id')[0] if kwargs.get('user_id') else None
 
         properties, changeids, sourcestamps = yield self.gatherPropertiesAndChanges(**kwargs)
 
         properties.setProperty("reason", reason, "Force Build Form")
         properties.setProperty("owner", owner, "Force Build Form")
+        properties.setProperty("user_id", user_id, "Force Build Form")
 
         if 'selected_slave' in kwargs and kwargs['selected_slave'][0] != 'default':
             properties.setProperty("selected_slave", kwargs['selected_slave'][0], "Force Build Form")

--- a/master/buildbot/status/web/builder.py
+++ b/master/buildbot/status/web/builder.py
@@ -41,10 +41,14 @@ class ForceAction(ActionResource):
     @defer.inlineCallbacks
     def force(self, req, builderNames):
         master = self.getBuildmaster(req)
-        owner = self.getAuthz(req).getUsernameFull(req)
+        authz = self.getAuthz(req)
+        owner = authz.getUsernameFull(req)
+        username = authz.getUsername(req)
+        user_id = authz.getUserInfo(username).get('uid')
         scheduler_name = req.args.get("forcescheduler", ["<unknown>"])[0]
 
         args = self.decode_request_arguments(req)
+        args['user_id'] = user_id
 
         if scheduler_name == "<unknown>":
             scheduler = master.scheduler_manager.findSchedulerByBuilderName(

--- a/master/buildbot/test/unit/test_schedulers_forcesched.py
+++ b/master/buildbot/test/unit/test_schedulers_forcesched.py
@@ -135,7 +135,8 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                         property1_name='p1',property1_value='e',
                         property2_name='p2',property2_value='f',
                         property3_name='p3',property3_value='g',
-                        property4_name='p4',property4_value='h'
+                        property4_name='p4',property4_value='h',
+                        user_id=42,
                         )
         bsid,brids = res
 
@@ -155,6 +156,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                ('p4', ('h', 'Force Build Form')),
                                ('reason', ('because', 'Force Build Form')),
                                ('scheduler', ('testsched', 'Scheduler')),
+                               ('user_id', (42, 'Force Build Form')),
                                ],
                   sourcestampsetid=100),
              {'':
@@ -167,7 +169,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
         sched = self.makeScheduler()
 
         res = yield sched.force('user', branch='a', reason='because',revision='c',
-                        repository='d', project='p',
+                        repository='d', project='p', user_id=42,
                         )
         bsid,brids = res
 
@@ -183,6 +185,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                ('owner', ('user', 'Force Build Form')),
                                ('reason', ('because', 'Force Build Form')),
                                ('scheduler', ('testsched', 'Scheduler')),
+                               ('user_id', (42, 'Force Build Form')),
                                ],
                   sourcestampsetid=100),
              {'':
@@ -196,7 +199,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
 
         res = yield sched.force('user', builderNames=['a','b'],
                         branch='a', reason='because',revision='c',
-                        repository='d', project='p',
+                        repository='d', project='p', user_id=42,
                         )
         bsid,brids = res
 
@@ -212,6 +215,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                ('owner', ('user', 'Force Build Form')),
                                ('reason', ('because', 'Force Build Form')),
                                ('scheduler', ('testsched', 'Scheduler')),
+                               ('user_id', (42, 'Force Build Form')),
                                ],
                   sourcestampsetid=100),
              {'':
@@ -257,7 +261,8 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                         property1_name='p1',property1_value='e',
                         property2_name='p2',property2_value='f',
                         property3_name='p3',property3_value='g',
-                        property4_name='p4',property4_value='h'
+                        property4_name='p4',property4_value='h',
+                        user_id=42,
                         )
 
         bsid,brids = res
@@ -274,6 +279,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                ('p4', ('h', 'Force Build Form')),
                                ('reason', ('because', 'Force Build Form')),
                                ('scheduler', ('testsched', 'Scheduler')),
+                               ('user_id', (42, 'Force Build Form')),
                                ],
                   sourcestampsetid=100),
              {'foo': dict(codebase='foo', sourcestampsetid=100,
@@ -309,7 +315,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
         sched = self.makeScheduler(properties=[prop])
 
         if not req:
-            req = {name:value, 'reason':'because'}
+            req = {name:value, 'reason':'because', 'user_id': 42}
         try:
             bsid, brids = yield sched.force(owner, builderNames=['a'], **req)
         except Exception,e:
@@ -326,6 +332,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
             ('owner', ('user', 'Force Build Form')),
             ('reason', ('because', 'Force Build Form')),
             ('scheduler', ('testsched', 'Scheduler')),
+            ('user_id', (42, 'Force Build Form')),
         ]
 
         if expectKind is None:
@@ -362,22 +369,22 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
 
 
     def test_BooleanParameter_True(self):
-        req = dict(p1=True,reason='because')
+        req = dict(p1=True,reason='because', user_id=42)
         self.do_ParameterTest(expect=True, klass=BooleanParameter, req=req)
 
 
     def test_WhenBooleanParameterIsStringTrue_ThenPropertyIsSetToTrue(self):
-        req = dict(p1='True',reason='because')
+        req = dict(p1='True',reason='because', user_id=42)
         self.do_ParameterTest(expect=True, klass=BooleanParameter, req=req)
 
 
     def test_WhenBooleanParameterIsRandomString_ThenPropertyIsSetToFalse(self):
-        req = dict(p1='Foobar',reason='because')
+        req = dict(p1='Foobar',reason='because', user_id=42)
         self.do_ParameterTest(expect=False, klass=BooleanParameter, req=req)
 
 
     def test_BooleanParameter_False(self):
-        req = dict(p2=True,reason='because')
+        req = dict(p2=True,reason='because', user_id=42)
         self.do_ParameterTest(expect=False, klass=BooleanParameter, req=req)
 
 
@@ -428,7 +435,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                 multiple=True, debug=False)
 
     def test_WhenRequestDoesNotContainValueAndItIsReadonly_ThenPropertyIsNotAssigned(self):
-        self.do_ParameterTest(req=dict(reason='because'),
+        self.do_ParameterTest(req=dict(reason='because', user_id=42),
                 expect={},
                 expectKind=dict,
                 klass=IntParameter,
@@ -444,7 +451,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
         fields = [
             IntParameter(name="foo")
         ]
-        self.do_ParameterTest(req=dict(p1_foo='123', reason="because"),
+        self.do_ParameterTest(req=dict(p1_foo='123', reason="because", user_id=42),
                               expect=dict(foo=123),
                               klass=NestedParameter, fields=fields)
 
@@ -460,7 +467,8 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                        p1_inner_str="bar",
                                        p1_inner_any_name="hello",
                                        p1_inner_any_value="world",
-                                       reason="because"),
+                                       reason="because",
+                                       user_id=42),
                               expect=dict(foo=123, inner=dict(str="bar", hello="world")),
                               klass=NestedParameter, fields=fields)
 
@@ -485,7 +493,8 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                        bar_a_name="a",
                                        bar_a_value="7",
                                        bar_b_name="b",
-                                       bar_b_value="8"),
+                                       bar_b_value="8",
+                                       user_id=42),
                               expect=dict(foo=123,
                                           inner=dict(str="bar", hello="world"),
                                           bar={'a':'7', 'b':'8'}),
@@ -496,7 +505,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
     def test_specifySlave(self):
         sched = self.makeScheduler()
         res = yield sched.force('user', 'a', branch='a', repository='http://repo', reason='because',
-                                selected_slave='slave1')
+                                selected_slave='slave1', user_id=42)
         bsid, brids = res
         self.db.buildsets.assertBuildset(bsid, dict(
             reason="A build was forced by 'user': because",
@@ -506,7 +515,8 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                               ('owner', ('user', 'Force Build Form')),
                               ('reason', ('because', 'Force Build Form')),
                               ('scheduler', ('testsched', 'Scheduler')),
-                              ('selected_slave', ('slave1', 'Force Build Form'))],
+                              ('selected_slave', ('slave1', 'Force Build Form')),
+                              ('user_id', (42, 'Force Build Form'))],
             sourcestampsetid=100),
             {'': {'branch': 'a', 'codebase': '', 'project': '', 'repository': 'http://repo', 'revision': '',
                   'sourcestampsetid': 100}})
@@ -535,7 +545,7 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
             makeFakeSlave('slave-03', paused=True)]
 
         res = yield sched.force('user', 'a', branch='a', repository='http://repo', reason='because',
-                                selected_slave='allCompatible')
+                                selected_slave='allCompatible', user_id=42)
 
         self.assertTrue(len(res) == 3)
 
@@ -549,7 +559,8 @@ class TestForceScheduler(scheduler.SchedulerMixin, ConfigErrorsMixin, unittest.T
                                   ('owner', ('user', 'Force Build Form')),
                                   ('reason', ('because', 'Force Build Form')),
                                   ('scheduler', ('testsched', 'Scheduler')),
-                                  ('selected_slave', (slavename, 'Scheduler'))],
+                                  ('selected_slave', (slavename, 'Scheduler')),
+                                  ('user_id', (42, 'Force Build Form'))],
                 sourcestampsetid=ssid),
                 {'': {'branch': 'a', 'codebase': '', 'project': '', 'repository': 'http://repo', 'revision': '',
                       'sourcestampsetid': ssid}})

--- a/master/buildbot/test/unit/test_status_build.py
+++ b/master/buildbot/test/unit/test_status_build.py
@@ -161,6 +161,14 @@ class TestBuildGetSourcestamps(unittest.TestCase):
 
 
 class TestBuildStatusUtils(unittest.TestCase):
+    BUILD_NUMBER = 33
+
+    def setUp(self):
+        self.builder_status = FakeBuilderStatus()
+        self.master = fakemaster.make_master()
+        self.build_status = build.BuildStatus(self.builder_status, self.master,
+                                              self.BUILD_NUMBER)
+
     @mock.patch('buildbot.status.web.base.path_to_build_by_params')
     def test_get_url_and_name_build_in_chain_with_selected_build_in_chain(self, path_mock):
         path_mock.return_value = "http://example.com/example/url"
@@ -201,6 +209,50 @@ class TestBuildStatusUtils(unittest.TestCase):
 
         self.assertEqual(build_url, None)
         self.assertEqual(build_name, None)
+
+    def test_setUserID(self):
+        self.build_status.setUserID(5)
+
+        self.assertEqual(self.build_status.user_id, 5)
+
+    @mock.patch("klog.err_json")
+    def test_setUserID_from_owners(self, err_json):
+        self.build_status.owners = ['pyflakes <pyflakes@unity3d.com>']
+        self.build_status.master.db = mock.Mock()
+        self.build_status.master.db.users.getUidByLdapUsername = mock.Mock(return_value=6)
+        self.build_status.builder.project = "Test Project"
+        self.build_status.builder.name = "Test Builder"
+
+        self.build_status.setUserID(None)
+
+        self.assertEqual(self.build_status.user_id, 6)
+        self.assertEqual(err_json.called, True)
+
+    @mock.patch("klog.err_json")
+    def test_setUserID_unknown_owner(self, err_json):
+        self.build_status.owners = ['pyflakes <pyflakes@unity3d.com>']
+        self.build_status.master.db = mock.Mock()
+        self.build_status.master.db.users.getUidByLdapUsername = mock.Mock(return_value=None)
+        self.build_status.builder.project = "Test Project"
+        self.build_status.builder.name = "Test Builder"
+
+        self.build_status.setUserID(None)
+
+        self.assertEqual(self.build_status.user_id, None)
+        self.assertEqual(err_json.called, True)
+
+    @mock.patch("klog.err_json")
+    def test_setUserID_empty_owners(self, err_json):
+        self.build_status.owners = []
+        self.build_status.master.db = mock.Mock()
+        self.build_status.master.db.users.getUidByLdapUsername = mock.Mock(return_value=7)
+        self.build_status.builder.project = "Test Project"
+        self.build_status.builder.name = "Test Builder"
+
+        self.build_status.setUserID(None)
+
+        self.assertEqual(self.build_status.user_id, None)
+        self.assertEqual(err_json.called, True)
 
 
 class BuildStepStub:


### PR DESCRIPTION
Use user_id from request instead searching user_id un users table via the query `tbl.c.identifier.like('{} <%'.format(username))`

This is a proof-of-concept. Probably taking user_id in ForceScheduler is sufficient but we should check how this works with a periodic build.

For situation when user_id in the parameter is `None` but we can choose it from `self.owners` we setup it in "old way" and log it by klog. After deploy we will check if a message "Found user_id in old way" will be logged in logz.