### PR TITLE
CDSK-926 - add customArtifactPath

### DIFF
--- a/master/buildbot/steps/artifact.py
+++ b/master/buildbot/steps/artifact.py
@@ -321,7 +321,7 @@ class CreateArtifactDirectory(ShellCommand):
         if self.customArtifactPath:
             artifactPath = self.customArtifactPath
         else:
-            artifactPath  = "%s/%s_%s" % (self.build.builder.config.builddir,
+            artifactPath = "%s/%s_%s" % (self.build.builder.config.builddir,
                                           br.id, FormatDatetime(mkdt(br.submittedAt)))
 
         if (self.artifactDirectory):
@@ -414,7 +414,7 @@ class UploadArtifact(ShellCommand):
         if self.customArtifactPath:
             artifactPath = self.customArtifactPath
         else:
-            artifactPath  = "%s/%s_%s" % (self.build.builder.config.builddir, br.id, FormatDatetime(mkdt(br.submittedAt)))
+            artifactPath = "%s/%s_%s" % (self.build.builder.config.builddir, br.id, FormatDatetime(mkdt(br.submittedAt)))
 
         artifactServerPath = self.build.getProperty("artifactServerPath", None)
         if artifactServerPath is None:
@@ -472,7 +472,7 @@ class DownloadArtifact(ShellCommand):
         if self.customArtifactPath:
             artifactPath = self.customArtifactPath
         else:
-            artifactPath  = "%s/%s_%s" % (safeTranslate(self.artifactBuilderName),
+            artifactPath = "%s/%s_%s" % (safeTranslate(self.artifactBuilderName),
                                           br['brid'], FormatDatetime(br["submitted_at"]))
 
         if (self.artifactDirectory):

--- a/master/buildbot/test/unit/test_step_artifact.py
+++ b/master/buildbot/test/unit/test_step_artifact.py
@@ -1,10 +1,16 @@
 from twisted.trial import unittest
 from buildbot.test.util import steps
 
+from buildbot.process.properties import Interpolate
 from buildbot.steps import artifact
 from buildbot.status.results import SUCCESS
 from buildbot.test.fake.remotecommand import ExpectShell
 from buildbot.test.fake import fakemaster, fakedb
+
+
+class StubSourceStamp(object):
+    def asDict(self):
+        return {'codebase': 'fmod', 'revision': 'abcde'}
 
 
 class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
@@ -14,12 +20,13 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
     def tearDown(self):
         return self.tearDownBuildStep()
 
-    def setupStep(self, step, brqs=None, winslave=False):
+    def setupStep(self, step, brqs=None, winslave=False, sources=None):
         steps.BuildStepMixin.setupStep(self, step)
 
         self.remote = '\'usr@srv.com:/home/srv/web/dir/build/1_17_12_2014_13_31_26_+0000/mydir/myartifact.py\''
         self.remote_2 = '\'usr@srv.com:/home/srv/web/dir/B/2_01_01_1970_00_00_00_+0000/mydir/myartifact.py\''
         self.remote_custom = '\'usr@srv.com:/home/srv/web/dir/foobar/mydir/myartifact.py\''
+        self.remote_custom_interpolate = '\'usr@srv.com:/home/srv/web/dir/Art-abcde/mydir/myartifact.py\''
         self.local = '\'myartifact.py\''
 
         fake_br = fakedb.BuildRequest(id=1, buildsetid=1, buildername="A", complete=1, results=0)
@@ -36,6 +43,7 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
             breqs += brqs
 
         self.build.slavebuilder.slave.slave_environ = {}
+        self.build.sources = sources or {}
 
         if winslave:
             self.build.slavebuilder.slave.slave_environ['os'] = 'Windows_NT'
@@ -87,6 +95,27 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS, status_text=['Remote artifact directory created.'])
         return self.runStep()
+
+    def test_create_artifact_directory_with_customArtifactPath_as_Interpolate(self):
+        customArtifactPath = Interpolate("Art-%(src:fmod:revision)s")
+        sourcestamp = StubSourceStamp()
+        self.setupStep(artifact.CreateArtifactDirectory(artifactDirectory="mydir",
+                                                        artifactServer='usr@srv.com',
+                                                        artifactServerDir='/home/srv/web/dir',
+                                                        artifactServerPort=222,
+                                                        customArtifactPath=customArtifactPath),
+                       sources={'fmod': sourcestamp})
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command=['ssh', 'usr@srv.com', '-p 222', 'cd /home/srv/web/dir;',
+                                 'mkdir -p ',
+                                 'Art-abcde/mydir'])
+            + ExpectShell.log('stdio', stdout='')
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=['Remote artifact directory created.'])
+        return self.runStep()
+
 
     def test_upload_artifact(self):
         self.setupStep(artifact.UploadArtifact(artifact="myartifact.py", artifactDirectory="mydir",
@@ -142,6 +171,29 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS, status_text=['Artifact(s) uploaded.'])
         self.expectProperty('artifactServerPath',
                             'http://srv.com/dir/foobar',
+                            'UploadArtifact')
+        return self.runStep()
+
+    def test_upload_artifact_with_customArtifactPath_as_Interpolate(self):
+        customArtifactPath = Interpolate("Art-%(src:fmod:revision)s")
+        sourcestamp = StubSourceStamp()
+        self.setupStep(artifact.UploadArtifact(artifact="myartifact.py", artifactDirectory="mydir",
+                                               artifactServer='usr@srv.com',
+                                               artifactServerDir='/home/srv/web/dir',
+                                               artifactServerURL="http://srv.com/dir",
+                                               customArtifactPath=customArtifactPath),
+                       sources={'fmod': sourcestamp})
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command='for i in 1 2 3 4 5; do rsync -var --progress --partial ' +
+                                self.local + ' ' + self.remote_custom_interpolate +
+                                '; if [ $? -eq 0 ]; then exit 0; else sleep 5; fi; done; exit -1')
+            + ExpectShell.log('stdio', stdout='')
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=['Artifact(s) uploaded.'])
+        self.expectProperty('artifactServerPath',
+                            'http://srv.com/dir/Art-abcde',
                             'UploadArtifact')
         return self.runStep()
 
@@ -273,6 +325,29 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS, status_text=["Downloaded 'B'."])
         return self.runStep()
 
+    def test_download_artifact_with_customArtifactPath_as_Interpolate(self):
+        customArtifactPath = Interpolate("Art-%(src:fmod:revision)s")
+        sourcestamp = StubSourceStamp()
+        fake_trigger = fakedb.BuildRequest(id=2, buildsetid=2, buildername="B", complete=1,
+                                           results=0, triggeredbybrid=1, startbrid=1)
+        self.setupStep(artifact.DownloadArtifact(artifactBuilderName="B", artifact="myartifact.py",
+                                                 artifactDirectory="mydir",
+                                                 artifactServer='usr@srv.com',
+                                                 artifactServerDir='/home/srv/web/dir',
+                                                 customArtifactPath=customArtifactPath),
+                       [fake_trigger],
+                       sources={'fmod': sourcestamp})
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command='for i in 1 2 3 4 5; do rsync -var --progress --partial ' +
+                                self.remote_custom_interpolate + ' ' + self.local +
+                                '; if [ $? -eq 0 ]; then exit 0; else sleep 5; fi; done; exit -1')
+            + ExpectShell.log('stdio', stdout='')
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=["Downloaded 'B'."])
+        return self.runStep()
 
     def test_download_artifact_Win_DOS(self):
         fake_trigger = fakedb.BuildRequest(id=2, buildsetid=2, buildername="B", complete=1,

--- a/master/buildbot/test/unit/test_step_artifact.py
+++ b/master/buildbot/test/unit/test_step_artifact.py
@@ -17,8 +17,8 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
     def setupStep(self, step, brqs=None, winslave=False):
         steps.BuildStepMixin.setupStep(self, step)
 
-        self.remote = '\'usr@srv.com:/home/srv/web/dir/build_1_17_12_2014_13_31_26_+0000/mydir/myartifact.py\''
-        self.remote_2 = '\'usr@srv.com:/home/srv/web/dir/B_2_01_01_1970_00_00_00_+0000/mydir/myartifact.py\''
+        self.remote = '\'usr@srv.com:/home/srv/web/dir/build/1_17_12_2014_13_31_26_+0000/mydir/myartifact.py\''
+        self.remote_2 = '\'usr@srv.com:/home/srv/web/dir/B/2_01_01_1970_00_00_00_+0000/mydir/myartifact.py\''
         self.local = '\'myartifact.py\''
 
         fake_br = fakedb.BuildRequest(id=1, buildsetid=1, buildername="A", complete=1, results=0)
@@ -48,7 +48,7 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             ExpectShell(workdir='wkdir', usePTY='slave-config',
                         command=['ssh', 'usr@srv.com', 'cd /home/srv/web/dir;', 'mkdir -p ',
-                                 'build_1_17_12_2014_13_31_26_+0000/mydir'])
+                                 'build/1_17_12_2014_13_31_26_+0000/mydir'])
             + ExpectShell.log('stdio', stdout='')
             + 0
         )
@@ -63,7 +63,7 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         self.expectCommands(
             ExpectShell(workdir='wkdir', usePTY='slave-config',
                         command=['ssh', 'usr@srv.com', '-p 222', 'cd /home/srv/web/dir;', 'mkdir -p ',
-                                 'build_1_17_12_2014_13_31_26_+0000/mydir'])
+                                 'build/1_17_12_2014_13_31_26_+0000/mydir'])
             + ExpectShell.log('stdio', stdout='')
             + 0
         )
@@ -84,7 +84,7 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS, status_text=['Artifact(s) uploaded.'])
         self.expectProperty('artifactServerPath',
-                            'http://srv.com/dir/build_1_17_12_2014_13_31_26_+0000',
+                            'http://srv.com/dir/build/1_17_12_2014_13_31_26_+0000',
                             'UploadArtifact')
         return self.runStep()
 
@@ -103,7 +103,7 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS, status_text=['Artifact(s) uploaded.'])
         self.expectProperty('artifactServerPath',
-                            'http://srv.com/dir/build_1_17_12_2014_13_31_26_+0000',
+                            'http://srv.com/dir/build/1_17_12_2014_13_31_26_+0000',
                             'UploadArtifact')
         return self.runStep()
 

--- a/master/buildbot/test/unit/test_step_artifact.py
+++ b/master/buildbot/test/unit/test_step_artifact.py
@@ -19,6 +19,7 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
 
         self.remote = '\'usr@srv.com:/home/srv/web/dir/build/1_17_12_2014_13_31_26_+0000/mydir/myartifact.py\''
         self.remote_2 = '\'usr@srv.com:/home/srv/web/dir/B/2_01_01_1970_00_00_00_+0000/mydir/myartifact.py\''
+        self.remote_custom = '\'usr@srv.com:/home/srv/web/dir/foobar/mydir/myartifact.py\''
         self.local = '\'myartifact.py\''
 
         fake_br = fakedb.BuildRequest(id=1, buildsetid=1, buildername="A", complete=1, results=0)
@@ -70,6 +71,23 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS, status_text=['Remote artifact directory created.'])
         return self.runStep()
 
+    def test_create_artifact_directory_with_customArtifactPath(self):
+        self.setupStep(artifact.CreateArtifactDirectory(artifactDirectory="mydir",
+                                                        artifactServer='usr@srv.com',
+                                                        artifactServerDir='/home/srv/web/dir',
+                                                        artifactServerPort=222,
+                                                        customArtifactPath='foobar'))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command=['ssh', 'usr@srv.com', '-p 222', 'cd /home/srv/web/dir;',
+                                 'mkdir -p ',
+                                 'foobar/mydir'])
+            + ExpectShell.log('stdio', stdout='')
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=['Remote artifact directory created.'])
+        return self.runStep()
+
     def test_upload_artifact(self):
         self.setupStep(artifact.UploadArtifact(artifact="myartifact.py", artifactDirectory="mydir",
                                                artifactServer='usr@srv.com', artifactServerDir='/home/srv/web/dir',
@@ -104,6 +122,26 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         self.expectOutcome(result=SUCCESS, status_text=['Artifact(s) uploaded.'])
         self.expectProperty('artifactServerPath',
                             'http://srv.com/dir/build/1_17_12_2014_13_31_26_+0000',
+                            'UploadArtifact')
+        return self.runStep()
+
+    def test_upload_artifact_with_customArtifactPath(self):
+        self.setupStep(artifact.UploadArtifact(artifact="myartifact.py", artifactDirectory="mydir",
+                                               artifactServer='usr@srv.com',
+                                               artifactServerDir='/home/srv/web/dir',
+                                               artifactServerURL="http://srv.com/dir",
+                                               customArtifactPath="foobar"))
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command='for i in 1 2 3 4 5; do rsync -var --progress --partial ' +
+                                self.local + ' ' + self.remote_custom +
+                                '; if [ $? -eq 0 ]; then exit 0; else sleep 5; fi; done; exit -1')
+            + ExpectShell.log('stdio', stdout='')
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=['Artifact(s) uploaded.'])
+        self.expectProperty('artifactServerPath',
+                            'http://srv.com/dir/foobar',
                             'UploadArtifact')
         return self.runStep()
 
@@ -213,6 +251,28 @@ class TestArtifactSteps(steps.BuildStepMixin, unittest.TestCase):
         )
         self.expectOutcome(result=SUCCESS, status_text=["Downloaded 'B'."])
         return self.runStep()
+
+    def test_download_artifact_with_customArtifactPath(self):
+        fake_trigger = fakedb.BuildRequest(id=2, buildsetid=2, buildername="B", complete=1,
+                                           results=0, triggeredbybrid=1, startbrid=1)
+        self.setupStep(artifact.DownloadArtifact(artifactBuilderName="B", artifact="myartifact.py",
+                                                 artifactDirectory="mydir",
+                                                 artifactServer='usr@srv.com',
+                                                 artifactServerDir='/home/srv/web/dir',
+                                                 customArtifactPath='foobar'),
+                       [fake_trigger])
+
+        self.expectCommands(
+            ExpectShell(workdir='wkdir', usePTY='slave-config',
+                        command='for i in 1 2 3 4 5; do rsync -var --progress --partial ' +
+                                self.remote_custom + ' ' + self.local +
+                                '; if [ $? -eq 0 ]; then exit 0; else sleep 5; fi; done; exit -1')
+            + ExpectShell.log('stdio', stdout='')
+            + 0
+        )
+        self.expectOutcome(result=SUCCESS, status_text=["Downloaded 'B'."])
+        return self.runStep()
+
 
     def test_download_artifact_Win_DOS(self):
         fake_trigger = fakedb.BuildRequest(id=2, buildsetid=2, buildername="B", complete=1,

--- a/master/buildbot/test/unit/test_steps_find_previous_build.py
+++ b/master/buildbot/test/unit/test_steps_find_previous_build.py
@@ -265,8 +265,8 @@ class TestFindPreviousSuccessfulBuild(steps.BuildStepMixin, config.ConfigErrorsM
                         command= ['ssh',
               'usr@srv.com',
               'cd /home/srv/web/dir;',
-              "if [ -d build_1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
-              'cd build_1_01_01_1970_00_00_00_+0000/artifact',
+              "if [ -d build/1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
+              'cd build/1_01_01_1970_00_00_00_+0000/artifact',
               '; ls myartifact.py',
               '; ls'])
             + ExpectShell.log('stdio', stdout='Not found!!')
@@ -290,8 +290,8 @@ class TestFindPreviousSuccessfulBuild(steps.BuildStepMixin, config.ConfigErrorsM
                         command= ['ssh',
               'usr@srv.com',
               'cd /home/srv/web/dir;',
-              "if [ -d build_1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
-              'cd build_1_01_01_1970_00_00_00_+0000/artifact',
+              "if [ -d build/1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
+              'cd build/1_01_01_1970_00_00_00_+0000/artifact',
               '; ls myartifact.py',
               '; ls'])
             + ExpectShell.log('stdio', stdout='')
@@ -314,8 +314,8 @@ class TestFindPreviousSuccessfulBuild(steps.BuildStepMixin, config.ConfigErrorsM
                         command= ['ssh',
               'usr@srv.com',
               'cd /home/srv/web/dir;',
-              "if [ -d build_1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
-              'cd build_1_01_01_1970_00_00_00_+0000/artifact',
+              "if [ -d build/1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
+              'cd build/1_01_01_1970_00_00_00_+0000/artifact',
               '; ls myartifact.py',
               '; ls'])
             + ExpectShell.log('stdio', stdout='myartifact.py')
@@ -341,8 +341,8 @@ class TestFindPreviousSuccessfulBuild(steps.BuildStepMixin, config.ConfigErrorsM
                         command= ['ssh',
               'usr@srv.com',
               'cd /home/srv/web/dir;',
-              "if [ -d build_1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
-              'cd build_1_01_01_1970_00_00_00_+0000/artifact',
+              "if [ -d build/1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
+              'cd build/1_01_01_1970_00_00_00_+0000/artifact',
               '; ls myartifact.py',
               '; ls'])
             + ExpectShell.log('stdio', stdout='myartifact.py')
@@ -381,8 +381,8 @@ class TestFindPreviousSuccessfulBuild(steps.BuildStepMixin, config.ConfigErrorsM
                         command= ['ssh',
               'usr@srv.com',
               'cd /home/srv/web/dir;',
-              "if [ -d build_1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
-              'cd build_1_01_01_1970_00_00_00_+0000/artifact',
+              "if [ -d build/1_01_01_1970_00_00_00_+0000/artifact ]; then echo 'Exists'; else echo 'Not found!!'; fi;",
+              'cd build/1_01_01_1970_00_00_00_+0000/artifact',
               '; ls myartifact.py',
               '; ls'])
             + ExpectShell.log('stdio', stdout='myartifact.py')


### PR DESCRIPTION
Add `customArtifactPath` to CreateArtifactDirectory, UploadArtifact, DownloadArtifact, CheckArtifactExists.

`customArtifactPat` has type `str`

Example:
```
----- master.cfg -----

def artifactsTestFactory():
    ...
    factory.addStep(CreateArtifactDirectory(
        artifactServer=artifactServer,
        artifactServerDir=artifactServerDir,
        artifactServerPort=artifactServerPort,
        customArtifactPath="bubbles",  # <------- HERE
    ))
    factory.addStep(UploadArtifact(
        artifact="DeveloperTest.artifact.txt",
        artifactServer=artifactServer,
        artifactServerDir=artifactServerDir,
        artifactServerURL=artifactServerURL,
        artifactServerPort=artifactServerPort,
        customArtifactPath=""bubbles", # <------- HERE
    ))


----- server -----

/artifacts/bubbles# ls
DeveloperTest.artifact.txt
/artifacts/bubbles# cat DeveloperTest.artifact.txt 
We like good burgers and pizza
```
