### PR TITLE
CDSK-928 - add debug for Failure.type

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -806,6 +806,10 @@ class BuildStep(object, properties.PropertiesMixin):
             try:
                 self.addCompleteLog("err.text", why.getTraceback())
                 self.addHTMLLog("err.html", formatFailure(why))
+            except AttributeError:
+                klog.err_json(
+                    Failure(), "DEBUG formatting exc. why.type: %s %s" % (why.type, type(why.type))
+                )
             except Exception:
                 klog.err_json(Failure(), "error while formatting exceptions")
 


### PR DESCRIPTION
We want to know what string is into Failure.type. Maybe with this information, we will be able to find a way to change Failure.type again into `type()`