### PR TITLE
CDSK-953 - fix Interpolate has no length exception

### DIFF
--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -202,7 +202,7 @@ class ShellCommand(buildstep.LoggingBuildStep):
             if isinstance(words, (str, unicode)):
                 words = words.split()
             elif isinstance(words, Interpolate):
-                return str(words)
+                return [str(words)]
 
             try:
                 len(words)

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -199,10 +199,10 @@ class ShellCommand(buildstep.LoggingBuildStep):
                 return ["???"]
 
             words = self.command
+            if isinstance(words, Interpolate):
+                words = words.getRenderingFor(self.build).result
             if isinstance(words, (str, unicode)):
                 words = words.split()
-            elif isinstance(words, Interpolate):
-                return [str(words)]
 
             try:
                 len(words)

--- a/master/buildbot/steps/shell.py
+++ b/master/buildbot/steps/shell.py
@@ -19,6 +19,7 @@ import inspect
 from twisted.python import log, failure
 from twisted.spread import pb
 from buildbot.process import buildstep
+from buildbot.process.properties import Interpolate
 from buildbot.status.results import SUCCESS, WARNINGS, FAILURE
 from buildbot.status.logfile import STDOUT, STDERR
 from buildbot import config
@@ -200,6 +201,8 @@ class ShellCommand(buildstep.LoggingBuildStep):
             words = self.command
             if isinstance(words, (str, unicode)):
                 words = words.split()
+            elif isinstance(words, Interpolate):
+                return str(words)
 
             try:
                 len(words)

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -75,7 +75,7 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
     def test_describe_with_command_Interpolate(self):
         command = Interpolate("echo 'test %s'", 'one fish')
         step = shell.ShellCommand(command=command)
-        self.assertEqual(step.describe(), str(command))
+        self.assertEqual(step.describe(), [str(command)])
 
     def test_describe_no_command(self):
         step = shell.ShellCommand(workdir='build')

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -22,6 +22,7 @@ from buildbot.status.results import SKIPPED, SUCCESS, WARNINGS, FAILURE
 from buildbot.status.results import EXCEPTION
 from buildbot.test.util import steps, compat
 from buildbot.test.util import config as configmixin
+from buildbot.test.fake.fakebuild import FakeBuild
 from buildbot.test.fake.remotecommand import ExpectShell, Expect
 from buildbot.test.fake.remotecommand import ExpectRemoteRef
 from buildbot import config
@@ -73,9 +74,17 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
                             wrongArg1=1, wrongArg2='two'))
 
     def test_describe_with_command_Interpolate(self):
-        command = Interpolate("echo 'test %s'", 'one fish')
+        bash_command = "sleep %d"
+        bash_command_arg = 60
+        expected_output = ["'sleep", "60'"]
+        build = FakeBuild()
+
+        command = Interpolate(bash_command, bash_command_arg)
         step = shell.ShellCommand(command=command)
-        self.assertEqual(step.describe(), [str(command)])
+        step.build = build
+        output = step.describe()
+
+        self.assertEqual(expected_output, output)
 
     def test_describe_no_command(self):
         step = shell.ShellCommand(workdir='build')

--- a/master/buildbot/test/unit/test_steps_shell.py
+++ b/master/buildbot/test/unit/test_steps_shell.py
@@ -16,6 +16,7 @@
 import re
 import textwrap
 from twisted.trial import unittest
+from buildbot.process.properties import Interpolate
 from buildbot.steps import shell
 from buildbot.status.results import SKIPPED, SUCCESS, WARNINGS, FAILURE
 from buildbot.status.results import EXCEPTION
@@ -70,6 +71,11 @@ class TestShellCommandExecution(steps.BuildStepMixin, unittest.TestCase, configm
                     "Invalid argument(s) passed to RemoteShellCommand: ",
                     lambda: shell.ShellCommand('build', "echo Hello World",
                             wrongArg1=1, wrongArg2='two'))
+
+    def test_describe_with_command_Interpolate(self):
+        command = Interpolate("echo 'test %s'", 'one fish')
+        step = shell.ShellCommand(command=command)
+        self.assertEqual(step.describe(), str(command))
 
     def test_describe_no_command(self):
         step = shell.ShellCommand(workdir='build')


### PR DESCRIPTION
Interpolate is not Iterable so we can resolve Interpolate to string and continue do a stuff in ShellCommand._describe