### PR TITLE
CDSK-928 - fix Failure.type by setup why.type with locate()

### DIFF
--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -807,6 +807,7 @@ class BuildStep(object, properties.PropertiesMixin):
                 if isinstance(why.type, str):
                     klog.err_json("Failure.type is string: [name: %s] [builder: %s] " %
                                   (self.name, self.build))
+                    why = Failure(why)  # ensure CopiedFailure -> Failure
                     why.type = locate(why.type) or why.type
                 self.addCompleteLog("err.text", why.getTraceback())
                 self.addHTMLLog("err.html", formatFailure(why))

--- a/master/buildbot/process/buildstep.py
+++ b/master/buildbot/process/buildstep.py
@@ -14,6 +14,7 @@
 # Copyright Buildbot Team Members
 
 import re
+from pydoc import locate
 
 from zope.interface import implements
 from twisted.internet import defer, error
@@ -797,19 +798,18 @@ class BuildStep(object, properties.PropertiesMixin):
         if why.check(BuildStepFailed):
             self.finished(FAILURE)
             return
-
         klog.err_json(why, "BuildStep.failed; traceback follows")
         results = EXCEPTION
         try:
             if self.progress:
                 self.progress.finish()
             try:
+                if isinstance(why.type, str):
+                    klog.err_json("Failure.type is string: [name: %s] [builder: %s] " %
+                                  (self.name, self.build))
+                    why.type = locate(why.type) or why.type
                 self.addCompleteLog("err.text", why.getTraceback())
                 self.addHTMLLog("err.html", formatFailure(why))
-            except AttributeError:
-                klog.err_json(
-                    Failure(), "DEBUG formatting exc. why.type: %s %s" % (why.type, type(why.type))
-                )
             except Exception:
                 klog.err_json(Failure(), "error while formatting exceptions")
 


### PR DESCRIPTION
I think the main problem causes creating new Failure when master received Failure from a slave.
Slave sends Failure as CopyableFailure because this object has a serializable format for a network.
Master receives data and makes CopiedFailure.
But first defer stack has `failed` method in `addErrback` and this method "catch" something like Failure so it creates Failure. Later `failed` method tries to create error files but Failure (which was CopiedFailure) has `Failure.type` string and cannot do `getTraceback()`.

Solution: re-create `type()` for `why.type` (if it's a string) via `pydoc.locate` method.

I removed `except` with `DEBUG` and added new klog to print the name of `LoggingBuildStep` and `Build`.

Below visualization of calling methods and transfer data.
![step-command-slave](https://user-images.githubusercontent.com/3229216/39625559-3d78b72e-4f9e-11e8-91c4-7ff66a92faf2.png)



