### PR TITLE
CDSK-931 - fix NotClaimedError, AlreadyClaimedError

### DIFF
--- a/master/buildbot/process/buildrequest.py
+++ b/master/buildbot/process/buildrequest.py
@@ -274,8 +274,10 @@ class BuildRequest(object):
             # then complete it with 'FAILURE'; this is the closest we can get to
             # cancelling a request without running into trouble with dangling
             # references.
-            yield self.master.db.buildrequests.completeBuildRequests([self.id],
-                                                                    CANCELED)
+            try:
+                yield self.master.db.buildrequests.completeBuildRequests([self.id], CANCELED)
+            except buildrequests.NotClaimedError:
+                klog.err_json("NotClaimedError occurs. buildrequest table was updated earlier")
 
         # and let the master know that the enclosing buildset may be complete
         yield self.master.maybeBuildsetComplete(self.bsid)

--- a/master/buildbot/process/buildrequestdistributor.py
+++ b/master/buildbot/process/buildrequestdistributor.py
@@ -1337,7 +1337,12 @@ class KatanaBuildRequestDistributor(service.Service):
             return
 
         # claim brid's
-        yield self.katanaBuildChooser.claimBuildRequests(breqs)
+        try:
+            yield self.katanaBuildChooser.claimBuildRequests(breqs)
+        except AlreadyClaimedError:
+            klog.err_json("_maybeStartBuildsOnBuilder: breqs were already claimed. Don't proceed them")
+            defer.returnValue(False)
+            return
 
         buildDefered = self.katanaBuildChooser.bldr.maybeStartBuild(slave, breqs)
         buildDefered.addErrback(self._requeue, breqs, self.katanaBuildChooser.bldr.name)

--- a/master/buildbot/test/unit/test_process_buildrequest.py
+++ b/master/buildbot/test/unit/test_process_buildrequest.py
@@ -371,11 +371,11 @@ class TestBuildRequest(unittest.TestCase):
     def test_cancelBuildRequest_for_NotClaimedError(self, mock_completeBuildRequests):
         mock_completeBuildRequests.side_effect = NotClaimedError
 
-        def checkCanceled(brdict, func):
+        def checkCanceled(brdict, mocked_func):
             # NotClaimedError was raised and results wasn't changed to CANCELED
             self.assertEqual(brdict['results'], INTERRUPTED)
             self.assertEqual(brdict['complete'], 1)
-            self.assertEqual(func.called, True)
+            self.assertEqual(mocked_func.called, True)
 
         master = fakemaster.make_master()
         master.db = fakedb.FakeDBConnector(self)


### PR DESCRIPTION
[from slack]
I know that production raises NotClaimedError, but when I try to reproduce the error (many dependencies in queue + Stop Entire Build Chain) my local Katana was raised AlreadyClaimedError and in my opinion, this bug is similar to NotClaimedError.
I think the best way to solve it is: add `try: except:` on these Exceptions and add klog with information that error occurs. We will have some information and code will not break and builds will finish in a correct way (I hope).

For both cases, I've added tests. Tests raise Exception (Not../Alredy..) and check if klog was called or return_value is correct.